### PR TITLE
Fix NeCard tooltip and minor fixes

### DIFF
--- a/src/components/NeCard.vue
+++ b/src/components/NeCard.vue
@@ -59,18 +59,20 @@ defineEmits(['titleClick'])
     <!-- header -->
     <div class="flex justify-between">
       <!-- title -->
-      <h3
-        v-if="title || $slots.title"
-        class="mb-3 font-semibold leading-6 text-gray-900 dark:text-gray-50"
-      >
-        <span v-if="title">
-          {{ title }}
-        </span>
-        <slot v-if="$slots.title" name="title"></slot>
+      <div class="mb-3 flex items-center gap-1">
+        <h3
+          v-if="title || $slots.title"
+          class="font-semibold leading-6 text-gray-900 dark:text-gray-50"
+        >
+          <span v-if="title">
+            {{ title }}
+          </span>
+          <slot v-if="$slots.title" name="title"></slot>
+        </h3>
         <span v-if="$slots.titleTooltip" class="ml-1">
           <slot name="titleTooltip"></slot>
         </span>
-      </h3>
+      </div>
       <!-- top-right slot (e.g. for kebab menu) -->
       <div
         v-if="$slots.topRight || menuItems?.length"

--- a/src/components/NeModal.vue
+++ b/src/components/NeModal.vue
@@ -169,7 +169,7 @@ function onSecondaryClick() {
                     </div>
                   </div>
                 </div>
-                <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+                <div class="mt-6 sm:flex sm:flex-row-reverse">
                   <NeButton
                     :kind="primaryButtonKind"
                     size="lg"

--- a/src/components/NeTooltip.vue
+++ b/src/components/NeTooltip.vue
@@ -51,14 +51,14 @@ defineProps({
 
 <template>
   <Tippy :interactive="interactive" :placement="placement" :trigger="triggerEvent" theme="tailwind">
-    <span class="inline-flex cursor-pointer">
+    <button type="button" class="inline-flex">
       <slot name="trigger">
         <FontAwesomeIcon
           :icon="faCircleInfo"
           class="h-4 w-4 text-indigo-500 dark:text-indigo-300"
         />
       </slot>
-    </span>
+    </button>
     <template #content>
       <slot name="content" />
     </template>


### PR DESCRIPTION
Fix style of NeCard tooltip: before this change it inherited the font weight of card title

Other changes:
- Fix style of NeModal buttons
- Render NeTooltip as a `button` to make it more accessible (i.e. making it selectable by keyboard)