### PR TITLE
fix!: propagate types to downstream projects

### DIFF
--- a/src/components/NeExpandable.vue
+++ b/src/components/NeExpandable.vue
@@ -7,7 +7,7 @@
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
 import { onMounted, ref, watch } from 'vue'
-import { NeButton } from '@/main'
+import NeButton from './NeButton.vue'
 
 const props = defineProps({
   label: {

--- a/src/components/NeFileInput.vue
+++ b/src/components/NeFileInput.vue
@@ -7,7 +7,7 @@
 import { computed } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faFileArrowUp } from '@fortawesome/free-solid-svg-icons'
-import NeProgressBar from '@/components/NeProgressBar.vue'
+import NeProgressBar from './NeProgressBar.vue'
 
 interface FileInputProps {
   modelValue?: File | File[] | null
@@ -107,7 +107,7 @@ const dragOverHandler = (event: Event) => {
               {{ dropZoneText }}
             </p>
           </div>
-          <input class="hidden" type="file" :accept="accept" />
+          <input :accept="accept" class="hidden" type="file" />
           <!-- progress bar -->
           <NeProgressBar
             v-if="showProgress"

--- a/src/components/NePaginator.vue
+++ b/src/components/NePaginator.vue
@@ -9,7 +9,7 @@ import { range } from 'lodash-es'
 import { faChevronLeft as fasChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { faChevronRight as fasChevronRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { NeListbox } from '@/main'
+import NeListbox from './NeListbox.vue'
 
 export type NePaginatorProps = {
   currentPage: number

--- a/src/components/NeRadioSelection.vue
+++ b/src/components/NeRadioSelection.vue
@@ -8,7 +8,7 @@ import { type PropType, type Ref, ref, watch } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons'
-import NeFormItemLabel from '@/components/NeFormItemLabel.vue'
+import NeFormItemLabel from './NeFormItemLabel.vue'
 
 export type RadioCardSize = 'md' | 'lg' | 'xl'
 

--- a/src/components/NeTable.vue
+++ b/src/components/NeTable.vue
@@ -9,7 +9,7 @@ import NeTableSkeleton from './NeTableSkeleton.vue'
 export type Breakpoint = 'sm' | 'md' | 'lg' | 'xl' | '2xl'
 
 const props = defineProps({
-  ariaLabel: {
+  label: {
     type: String,
     required: true
   },
@@ -46,7 +46,7 @@ const tableCardStyle: Record<Breakpoint, string> = {
   <div class="overflow-x-auto rounded-lg border border-gray-300 shadow-sm dark:border-gray-600">
     <table
       role="grid"
-      :aria-label="ariaLabel"
+      :aria-label="label"
       :class="[
         `grid w-full table-auto bg-white text-left text-sm font-normal text-gray-700 dark:bg-gray-950 dark:text-gray-200`,
         tableCardStyle[cardBreakpoint]

--- a/src/components/NeToastNotification.vue
+++ b/src/components/NeToastNotification.vue
@@ -7,7 +7,7 @@
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faXmark as fasXmark } from '@fortawesome/free-solid-svg-icons'
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { humanDistanceToNowLoc, formatDateLoc } from '../main'
+import { humanDistanceToNowLoc, formatDateLoc } from '../lib/dateTime'
 import NeButton from './NeButton.vue'
 import NeRoundedIcon from './NeRoundedIcon.vue'
 import NeTooltip from './NeTooltip.vue'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,48 +1,48 @@
 // style export
-import '@/main.css'
+import './main.css'
 
 // components export
-export { default as NeSkeleton } from '@/components/NeSkeleton.vue'
-export { default as NeSpinner } from '@/components/NeSpinner.vue'
-export { default as NeExpandable } from '@/components/NeExpandable.vue'
-export { default as NeProgressBar } from '@/components/NeProgressBar.vue'
-export { default as NeFileInput } from '@/components/NeFileInput.vue'
-export { default as NeInlineNotification } from '@/components/NeInlineNotification.vue'
-export { default as NeRoundedIcon } from '@/components/NeRoundedIcon.vue'
-export { default as NeSideDrawer } from '@/components/NeSideDrawer.vue'
-export { default as NeTooltip } from '@/components/NeTooltip.vue'
-export { default as NeBadge } from '@/components/NeBadge.vue'
-export { default as NeButton } from '@/components/NeButton.vue'
-export { default as NeCheckbox } from '@/components/NeCheckbox.vue'
-export { default as NeTable } from '@/components/NeTable.vue'
-export { default as NeTableHead } from '@/components/NeTableHead.vue'
-export { default as NeTableHeadCell } from '@/components/NeTableHeadCell.vue'
-export { default as NeTableBody } from '@/components/NeTableBody.vue'
-export { default as NeTableRow } from '@/components/NeTableRow.vue'
-export { default as NeTableCell } from '@/components/NeTableCell.vue'
-export { default as NeCombobox } from '@/components/NeCombobox.vue'
-export { default as NeDropdown } from '@/components/NeDropdown.vue'
-export { default as NeCard } from '@/components/NeCard.vue'
-export { default as NeLink } from '@/components/NeLink.vue'
-export { default as NeFormItemLabel } from '@/components/NeFormItemLabel.vue'
-export { default as NeRadioSelection } from '@/components/NeRadioSelection.vue'
-export { default as NePaginator } from '@/components/NePaginator.vue'
-export { default as NeEmptyState } from '@/components/NeEmptyState.vue'
-export { default as NeTabs } from '@/components/NeTabs.vue'
-export { default as NeTextArea } from '@/components/NeTextArea.vue'
-export { default as NeTextInput } from '@/components/NeTextInput.vue'
-export { default as NeToggle } from '@/components/NeToggle.vue'
-export { default as NeToastNotification } from '@/components/NeToastNotification.vue'
-export { default as NeModal } from '@/components/NeModal.vue'
-export { default as NeHeading } from '@/components/NeHeading.vue'
-export { default as NeListbox } from '@/components/NeListbox.vue'
+export { default as NeSkeleton } from './components/NeSkeleton.vue'
+export { default as NeSpinner } from './components/NeSpinner.vue'
+export { default as NeExpandable } from './components/NeExpandable.vue'
+export { default as NeProgressBar } from './components/NeProgressBar.vue'
+export { default as NeFileInput } from './components/NeFileInput.vue'
+export { default as NeInlineNotification } from './components/NeInlineNotification.vue'
+export { default as NeRoundedIcon } from './components/NeRoundedIcon.vue'
+export { default as NeSideDrawer } from './components/NeSideDrawer.vue'
+export { default as NeTooltip } from './components/NeTooltip.vue'
+export { default as NeBadge } from './components/NeBadge.vue'
+export { default as NeButton } from './components/NeButton.vue'
+export { default as NeCheckbox } from './components/NeCheckbox.vue'
+export { default as NeTable } from './components/NeTable.vue'
+export { default as NeTableHead } from './components/NeTableHead.vue'
+export { default as NeTableHeadCell } from './components/NeTableHeadCell.vue'
+export { default as NeTableBody } from './components/NeTableBody.vue'
+export { default as NeTableRow } from './components/NeTableRow.vue'
+export { default as NeTableCell } from './components/NeTableCell.vue'
+export { default as NeCombobox } from './components/NeCombobox.vue'
+export { default as NeDropdown } from './components/NeDropdown.vue'
+export { default as NeCard } from './components/NeCard.vue'
+export { default as NeLink } from './components/NeLink.vue'
+export { default as NeFormItemLabel } from './components/NeFormItemLabel.vue'
+export { default as NeRadioSelection } from './components/NeRadioSelection.vue'
+export { default as NePaginator } from './components/NePaginator.vue'
+export { default as NeEmptyState } from './components/NeEmptyState.vue'
+export { default as NeTabs } from './components/NeTabs.vue'
+export { default as NeTextArea } from './components/NeTextArea.vue'
+export { default as NeTextInput } from './components/NeTextInput.vue'
+export { default as NeToggle } from './components/NeToggle.vue'
+export { default as NeToastNotification } from './components/NeToastNotification.vue'
+export { default as NeModal } from './components/NeModal.vue'
+export { default as NeHeading } from './components/NeHeading.vue'
+export { default as NeListbox } from './components/NeListbox.vue'
 
 // types export
-export type { NeComboboxOption } from '@/components/NeCombobox.vue'
-export type { NePaginatorProps } from '@/components/NePaginator.vue'
-export type { Tab } from '@/components/NeTabs.vue'
-export type { NeNotification } from '@/components/NeToastNotification.vue'
-export type { NeListboxOption } from '@/components/NeListbox.vue'
+export type { NeComboboxOption } from './components/NeCombobox.vue'
+export type { NePaginatorProps } from './components/NePaginator.vue'
+export type { Tab } from './components/NeTabs.vue'
+export type { NeNotification } from './components/NeToastNotification.vue'
+export type { NeListboxOption } from './components/NeListbox.vue'
 
 // library functions export
 export {
@@ -52,14 +52,14 @@ export {
   byteFormat1024,
   byteFormat1000,
   kbpsFormat
-} from '@/lib/utils'
+} from './lib/utils'
 export {
   formatDateLoc,
   formatInTimeZoneLoc,
   getDateFnsLocale,
   formatDurationLoc,
   humanDistanceToNowLoc
-} from '@/lib/dateTime'
+} from './lib/dateTime'
 export {
   saveToStorage,
   getJsonFromStorage,
@@ -67,7 +67,7 @@ export {
   deleteFromStorage,
   savePreference,
   getPreference
-} from '@/lib/storage'
+} from './lib/storage'
 
 // composables export
-export { useItemPagination } from '@/composables/useItemPagination'
+export { useItemPagination } from './composables/useItemPagination'

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,9 +5,6 @@
   "compilerOptions": {
     "composite": true,
     "baseUrl": ".",
-    "outDir": "dist",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "dist"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,3 @@
-import { fileURLToPath, URL } from 'node:url'
-
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
@@ -38,10 +36,5 @@ export default defineConfig({
       }
     }
   },
-  plugins: [vue()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
-    }
-  }
+  plugins: [vue()]
 })


### PR DESCRIPTION
Typing is now checked while building applications that depends on this library, expect typescript builds to fail.
