### PR TITLE
feat: add options filtering to NeDropdownFilter

### DIFF
--- a/stories/NeDropdownFilter.stories.ts
+++ b/stories/NeDropdownFilter.stories.ts
@@ -32,13 +32,26 @@ const meta = {
       {
         id: 'option4',
         label: 'Option 4'
+      },
+      {
+        id: 'option5',
+        label: 'Option 5'
+      },
+      {
+        id: 'option6',
+        label: 'Option 6'
       }
     ],
     kind: 'checkbox',
-    clearFilterLabel: 'Clear filter',
+    clearFilterLabel: 'Clear selection',
     openMenuAriaLabel: 'Open filter',
     showClearFilter: true,
     showSelectionCount: true,
+    noOptionsLabel: 'No options',
+    showOptionsFilter: false,
+    optionsFilterPlaceholder: 'Filter options',
+    maxOptionsShown: 25,
+    moreOptionsHiddenLabel: 'Continue typing to show more options',
     alignToRight: false,
     size: 'md',
     disabled: false,
@@ -172,4 +185,49 @@ export const ButtonSlot: Story = {
     template: withSlotTemplate
   }),
   args: {}
+}
+
+export const NoOptions: Story = {
+  render: (args) => ({
+    components: { NeDropdownFilter },
+    setup() {
+      return { args }
+    },
+    template: template
+  }),
+  args: {
+    options: []
+  }
+}
+
+export const ShowOptionsFilter: Story = {
+  render: (args) => ({
+    components: { NeDropdownFilter },
+    setup() {
+      return { args }
+    },
+    template: template
+  }),
+  args: {
+    showOptionsFilter: true
+  }
+}
+
+const manyOptions: any = []
+
+for (let i = 0; i < 150; i++) {
+  manyOptions.push({ id: i.toString(), label: `Option ${i}` })
+}
+
+export const ManyOptions: Story = {
+  render: (args) => ({
+    components: { NeDropdownFilter },
+    setup() {
+      return { args }
+    },
+    template: template
+  }),
+  args: {
+    options: manyOptions
+  }
 }


### PR DESCRIPTION
Changes to NeDropdownFilter:
- Provide an optional text input for filtering options, allowing the user to choose whether to display it when there are many choices
- Introduce the `maxOptionsShown` prop to set the maximum number of options displayed (25 by default). If more options are available, the user is informed and can use the text input to filter and display matching options
- Automatically display the text input for filtering options when there are more than `maxOptionsShown` choices available
- Add the `noOptionsLabel` prop, displayed when no options are available or when the user's filter query doesn't match any options