### PR TITLE
fix!: enforcing types on parent projects

### DIFF
--- a/src/components/NeDropdownFilter.vue
+++ b/src/components/NeDropdownFilter.vue
@@ -14,7 +14,7 @@ import NeBadge from './NeBadge.vue'
 import NeLink from './NeLink.vue'
 import type { ButtonSize } from './NeButton.vue'
 import NeTextInput from './NeTextInput.vue'
-import { focusElement } from '@/main'
+import { focusElement } from '../lib/utils'
 
 export type FilterKind = 'radio' | 'checkbox'
 

--- a/src/components/NeExpandable.vue
+++ b/src/components/NeExpandable.vue
@@ -7,7 +7,7 @@
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
 import { onMounted, ref, watch } from 'vue'
-import { NeButton } from '@/main'
+import NeButton from './NeButton.vue'
 
 const props = defineProps({
   label: {

--- a/src/components/NeFileInput.vue
+++ b/src/components/NeFileInput.vue
@@ -7,7 +7,7 @@
 import { computed } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faFileArrowUp } from '@fortawesome/free-solid-svg-icons'
-import NeProgressBar from '@/components/NeProgressBar.vue'
+import NeProgressBar from './NeProgressBar.vue'
 
 interface FileInputProps {
   modelValue?: File | File[] | null

--- a/src/components/NePaginator.vue
+++ b/src/components/NePaginator.vue
@@ -9,7 +9,7 @@ import { range } from 'lodash-es'
 import { faChevronLeft as fasChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { faChevronRight as fasChevronRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { NeListbox } from '@/main'
+import NeListbox from './NeListbox.vue'
 
 const props = defineProps({
   currentPage: {

--- a/src/components/NeRadioSelection.vue
+++ b/src/components/NeRadioSelection.vue
@@ -8,7 +8,7 @@ import { computed, type PropType, type Ref, ref, watch } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { type IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons'
-import NeFormItemLabel from '@/components/NeFormItemLabel.vue'
+import NeFormItemLabel from './NeFormItemLabel.vue'
 import { v4 as uuidv4 } from 'uuid'
 
 export type RadioCardSize = 'md' | 'lg' | 'xl'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,51 +1,51 @@
 // style export
-import '@/main.css'
+import './main.css'
 
 // components export
-export { default as NeSkeleton } from '@/components/NeSkeleton.vue'
-export { default as NeSpinner } from '@/components/NeSpinner.vue'
-export { default as NeExpandable } from '@/components/NeExpandable.vue'
-export { default as NeProgressBar } from '@/components/NeProgressBar.vue'
-export { default as NeFileInput } from '@/components/NeFileInput.vue'
-export { default as NeInlineNotification } from '@/components/NeInlineNotification.vue'
-export { default as NeRoundedIcon } from '@/components/NeRoundedIcon.vue'
-export { default as NeSideDrawer } from '@/components/NeSideDrawer.vue'
-export { default as NeTooltip } from '@/components/NeTooltip.vue'
-export { default as NeBadge } from '@/components/NeBadge.vue'
-export { default as NeButton } from '@/components/NeButton.vue'
-export { default as NeCheckbox } from '@/components/NeCheckbox.vue'
-export { default as NeTable } from '@/components/NeTable.vue'
-export { default as NeTableHead } from '@/components/NeTableHead.vue'
-export { default as NeTableHeadCell } from '@/components/NeTableHeadCell.vue'
-export { default as NeTableBody } from '@/components/NeTableBody.vue'
-export { default as NeTableRow } from '@/components/NeTableRow.vue'
-export { default as NeTableCell } from '@/components/NeTableCell.vue'
-export { default as NeCombobox } from '@/components/NeCombobox.vue'
-export { default as NeDropdown } from '@/components/NeDropdown.vue'
-export { default as NeCard } from '@/components/NeCard.vue'
-export { default as NeLink } from '@/components/NeLink.vue'
-export { default as NeFormItemLabel } from '@/components/NeFormItemLabel.vue'
-export { default as NeRadioSelection } from '@/components/NeRadioSelection.vue'
-export { default as NePaginator } from '@/components/NePaginator.vue'
-export { default as NeEmptyState } from '@/components/NeEmptyState.vue'
-export { default as NeTabs } from '@/components/NeTabs.vue'
-export { default as NeTextArea } from '@/components/NeTextArea.vue'
-export { default as NeTextInput } from '@/components/NeTextInput.vue'
-export { default as NeToggle } from '@/components/NeToggle.vue'
-export { default as NeToastNotification } from '@/components/NeToastNotification.vue'
-export { default as NeModal } from '@/components/NeModal.vue'
-export { default as NeHeading } from '@/components/NeHeading.vue'
-export { default as NeListbox } from '@/components/NeListbox.vue'
-export { default as NeDropdownFilter } from '@/components/NeDropdownFilter.vue'
-export { default as NeSortDropdown } from '@/components/NeSortDropdown.vue'
+export { default as NeSkeleton } from './components/NeSkeleton.vue'
+export { default as NeSpinner } from './components/NeSpinner.vue'
+export { default as NeExpandable } from './components/NeExpandable.vue'
+export { default as NeProgressBar } from './components/NeProgressBar.vue'
+export { default as NeFileInput } from './components/NeFileInput.vue'
+export { default as NeInlineNotification } from './components/NeInlineNotification.vue'
+export { default as NeRoundedIcon } from './components/NeRoundedIcon.vue'
+export { default as NeSideDrawer } from './components/NeSideDrawer.vue'
+export { default as NeTooltip } from './components/NeTooltip.vue'
+export { default as NeBadge } from './components/NeBadge.vue'
+export { default as NeButton } from './components/NeButton.vue'
+export { default as NeCheckbox } from './components/NeCheckbox.vue'
+export { default as NeTable } from './components/NeTable.vue'
+export { default as NeTableHead } from './components/NeTableHead.vue'
+export { default as NeTableHeadCell } from './components/NeTableHeadCell.vue'
+export { default as NeTableBody } from './components/NeTableBody.vue'
+export { default as NeTableRow } from './components/NeTableRow.vue'
+export { default as NeTableCell } from './components/NeTableCell.vue'
+export { default as NeCombobox } from './components/NeCombobox.vue'
+export { default as NeDropdown } from './components/NeDropdown.vue'
+export { default as NeCard } from './components/NeCard.vue'
+export { default as NeLink } from './components/NeLink.vue'
+export { default as NeFormItemLabel } from './components/NeFormItemLabel.vue'
+export { default as NeRadioSelection } from './components/NeRadioSelection.vue'
+export { default as NePaginator } from './components/NePaginator.vue'
+export { default as NeEmptyState } from './components/NeEmptyState.vue'
+export { default as NeTabs } from './components/NeTabs.vue'
+export { default as NeTextArea } from './components/NeTextArea.vue'
+export { default as NeTextInput } from './components/NeTextInput.vue'
+export { default as NeToggle } from './components/NeToggle.vue'
+export { default as NeToastNotification } from './components/NeToastNotification.vue'
+export { default as NeModal } from './components/NeModal.vue'
+export { default as NeHeading } from './components/NeHeading.vue'
+export { default as NeListbox } from './components/NeListbox.vue'
+export { default as NeDropdownFilter } from './components/NeDropdownFilter.vue'
+export { default as NeSortDropdown } from './components/NeSortDropdown.vue'
 
 // types export
-export type { NeComboboxOption } from '@/components/NeCombobox.vue'
-export type { Tab } from '@/components/NeTabs.vue'
-export type { NeNotification } from '@/components/NeToastNotification.vue'
-export type { NeListboxOption } from '@/components/NeListbox.vue'
-export type { NeDropdownItem } from '@/components/NeDropdown.vue'
-export type { FilterOption, FilterKind } from '@/components/NeDropdownFilter.vue'
+export type { NeComboboxOption } from './components/NeCombobox.vue'
+export type { Tab } from './components/NeTabs.vue'
+export type { NeNotification } from './components/NeToastNotification.vue'
+export type { NeListboxOption } from './components/NeListbox.vue'
+export type { NeDropdownItem } from './components/NeDropdown.vue'
+export type { FilterOption, FilterKind } from './components/NeDropdownFilter.vue'
 
 // library functions export
 export {
@@ -55,14 +55,14 @@ export {
   byteFormat1024,
   byteFormat1000,
   kbpsFormat
-} from '@/lib/utils'
+} from './lib/utils'
 export {
   formatDateLoc,
   formatInTimeZoneLoc,
   getDateFnsLocale,
   formatDurationLoc,
   humanDistanceToNowLoc
-} from '@/lib/dateTime'
+} from './lib/dateTime'
 export {
   saveToStorage,
   getJsonFromStorage,
@@ -70,8 +70,8 @@ export {
   deleteFromStorage,
   savePreference,
   getPreference
-} from '@/lib/storage'
+} from './lib/storage'
 
 // composables export
-export { useItemPagination } from '@/composables/useItemPagination'
-export { useSort } from '@/composables/useSort'
+export { useItemPagination } from './composables/useItemPagination'
+export { useSort } from './composables/useSort'

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,8 +6,5 @@
     "composite": true,
     "baseUrl": ".",
     "outDir": "dist",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,3 @@
-import { fileURLToPath, URL } from 'node:url'
-
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
@@ -38,10 +36,5 @@ export default defineConfig({
       }
     }
   },
-  plugins: [vue()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
-    }
-  }
+  plugins: [vue()]
 })


### PR DESCRIPTION
Due to an issue with the `@` import helper the typescript declarations were not honoured correctly. This revamp allows the correct definitions to be consumed on parent projects and enforce typings correctly.
