### PR TITLE
fix!: replace string icons with IconDefinition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+# Output of 'npm pack'
+*.tgz

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "format": "prettier --list-different src/",
     "format-fix": "prettier --write src/",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "build-pack": "npm version patch --no-git-tag-version && npm run build && npm pack"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/src/components/NeDropdown.vue
+++ b/src/components/NeDropdown.vue
@@ -6,9 +6,9 @@
 <script lang="ts" setup>
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
 import NeButton from './NeButton.vue'
-import { library } from '@fortawesome/fontawesome-svg-core'
+import { type IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { faEllipsisVertical as fasEllipsisVertical } from '@fortawesome/free-solid-svg-icons'
+import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons'
 import { ref, watch } from 'vue'
 
 export interface Props {
@@ -28,14 +28,11 @@ const props = withDefaults(defineProps<Props>(), {
 export interface NeDropdownItem {
   id: string
   label?: string
-  icon?: string
-  iconStyle?: string
+  icon?: IconDefinition
   danger?: boolean
   action?: () => void
   disabled?: boolean
 }
-
-library.add(fasEllipsisVertical)
 
 function onItemClick(item: NeDropdownItem) {
   if (!item.disabled && item.action) {
@@ -84,11 +81,7 @@ watch(
       <slot name="button">
         <!-- default kebab button -->
         <NeButton class="py-2" kind="tertiary">
-          <FontAwesomeIcon
-            :icon="['fas', 'ellipsis-vertical']"
-            aria-hidden="true"
-            class="h-5 w-5 shrink-0"
-          />
+          <FontAwesomeIcon :icon="faEllipsisVertical" aria-hidden="true" class="h-5 w-5 shrink-0" />
         </NeButton>
       </slot>
     </MenuButton>
@@ -129,7 +122,7 @@ watch(
               >
                 <FontAwesomeIcon
                   v-if="item.icon"
-                  :icon="[item.iconStyle || 'fas', item.icon]"
+                  :icon="item.icon"
                   aria-hidden="true"
                   class="mr-2 h-5 w-5 shrink-0"
                 />

--- a/src/components/NeRadioSelection.vue
+++ b/src/components/NeRadioSelection.vue
@@ -6,7 +6,7 @@
 <script lang="ts" setup>
 import { computed, type PropType, type Ref, ref, watch } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { library } from '@fortawesome/fontawesome-svg-core'
+import { type IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons'
 import NeFormItemLabel from '@/components/NeFormItemLabel.vue'
 import { v4 as uuidv4 } from 'uuid'
@@ -17,8 +17,7 @@ type RadioOption = {
   id: string
   label: string
   description?: string
-  icon?: string
-  iconStyle?: string
+  icon?: IconDefinition
   disabled?: boolean
 }
 
@@ -76,8 +75,6 @@ const emit = defineEmits(['update:modelValue'])
 defineExpose({
   focus
 })
-
-library.add(faCircleCheck)
 
 const value: Ref<any> = ref(props.modelValue ?? '')
 
@@ -154,7 +151,7 @@ function focus() {
       >
         <FontAwesomeIcon
           v-if="option.icon"
-          :icon="[option.iconStyle ?? 'fas', option.icon]"
+          :icon="option.icon"
           :class="`${iconClasses[cardSize]}`"
         />
         <!-- custom content -->
@@ -171,7 +168,7 @@ function focus() {
         <!-- top-right selection icon -->
         <FontAwesomeIcon
           v-if="value == option.id && cardSelectionMark"
-          :icon="['fas', 'circle-check']"
+          :icon="faCircleCheck"
           :class="`absolute text-primary-700 dark:text-primary-500 ${selectionMarkClasses[cardSize]}`"
         />
       </button>

--- a/stories/NeDropdown.stories.ts
+++ b/stories/NeDropdown.stories.ts
@@ -4,19 +4,12 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 
 import { NeDropdown, NeButton } from '../src/main'
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { faPenToSquare as fasPenToSquare } from '@fortawesome/free-solid-svg-icons'
-import { faFloppyDisk as fasFloppyDisk } from '@fortawesome/free-solid-svg-icons'
-import { faTrashCan as fasTrashCan } from '@fortawesome/free-solid-svg-icons'
-import { faCopy as fasCopy } from '@fortawesome/free-solid-svg-icons'
-import { faChevronDown as fasChevronDown } from '@fortawesome/free-solid-svg-icons'
+import { faPenToSquare } from '@fortawesome/free-solid-svg-icons'
+import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons'
+import { faTrashCan } from '@fortawesome/free-solid-svg-icons'
+import { faCopy } from '@fortawesome/free-solid-svg-icons'
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-
-library.add(fasPenToSquare)
-library.add(fasFloppyDisk)
-library.add(fasTrashCan)
-library.add(fasCopy)
-library.add(fasChevronDown)
 
 const meta = {
   title: 'NeDropdown',
@@ -27,22 +20,19 @@ const meta = {
       {
         id: 'edit',
         label: 'Edit',
-        icon: 'pen-to-square',
-        iconStyle: 'fas',
+        icon: faPenToSquare,
         action: () => {}
       },
       {
         id: 'copy',
         label: 'Copy',
-        icon: 'copy',
-        iconStyle: 'fas',
+        icon: faCopy,
         action: () => {}
       },
       {
         id: 'save',
         label: 'Save',
-        icon: 'floppy-disk',
-        iconStyle: 'fas',
+        icon: faFloppyDisk,
         action: () => {},
         disabled: true
       },
@@ -52,8 +42,7 @@ const meta = {
       {
         id: 'delete',
         label: 'Delete',
-        icon: 'trash-can',
-        iconStyle: 'fas',
+        icon: faTrashCan,
         danger: true,
         action: () => {}
       }
@@ -98,7 +87,7 @@ const withSlotTemplate =
     <template #button>\
       <NeButton>\
         <template #suffix>\
-          <FontAwesomeIcon :icon="[\'fas\', \'chevron-down\']" class="h-4 w-4" aria-hidden="true" />\
+          <FontAwesomeIcon :icon="faChevronDown" class="h-4 w-4" aria-hidden="true" />\
         </template>\
         Menu\
       </NeButton>\
@@ -109,7 +98,7 @@ export const WithSlot: Story = {
   render: (args) => ({
     components: { NeDropdown, NeButton, FontAwesomeIcon },
     setup() {
-      return { args }
+      return { args, faChevronDown }
     },
     template: withSlotTemplate
   }),

--- a/stories/NeRadioSelection.stories.ts
+++ b/stories/NeRadioSelection.stories.ts
@@ -4,20 +4,12 @@
 import { Meta, StoryObj } from '@storybook/vue3'
 
 import { NeRadioSelection, NeTooltip } from '../src/main'
-import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   faEarthAmericas,
   faLocationDot,
   faShield,
-  faUserGroup,
-  faHardDrive
+  faUserGroup
 } from '@fortawesome/free-solid-svg-icons'
-
-library.add(faLocationDot)
-library.add(faEarthAmericas)
-library.add(faUserGroup)
-library.add(faShield)
-library.add(faHardDrive)
 
 const meta: Meta<typeof NeRadioSelection> = {
   title: 'NeRadioSelection',
@@ -101,36 +93,31 @@ export const CardPicker: StoryObj<typeof NeRadioSelection> = {
         id: '1',
         label: 'LAN',
         description: 'green',
-        icon: 'location-dot',
-        iconStyle: 'fas'
+        icon: faLocationDot
       },
       {
         id: '2',
         label: 'WAN',
         description: 'red',
-        icon: 'earth-americas',
-        iconStyle: 'fas'
+        icon: faEarthAmericas
       },
       {
         id: '3',
         label: 'Guests',
         description: 'blue',
-        icon: 'user-group',
-        iconStyle: 'fas'
+        icon: faUserGroup
       },
       {
         id: '4',
         label: 'DMZ',
         description: 'orange',
-        icon: 'shield',
-        iconStyle: 'fas',
+        icon: faShield,
         disabled: true
       },
       {
         id: '5',
         label: 'Custom Role',
-        icon: 'location-dot',
-        iconStyle: 'fas'
+        icon: faLocationDot
       }
     ]
   }


### PR DESCRIPTION
Use `IconDefinition` type instead of `string` for `NeRadioSelection` and `NeDropdown` icons.

Other changes:
- Add `build-pack` script