### PR TITLE
feat(NeCombobox): add customOptionsWidth prop

### DIFF
--- a/src/components/NeCombobox.vue
+++ b/src/components/NeCombobox.vue
@@ -54,6 +54,7 @@ export interface Props {
   acceptUserInput?: boolean
   userInputLabel: string
   optionalLabel: string
+  customOptionsWidth?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -68,7 +69,8 @@ const props = withDefaults(defineProps<Props>(), {
   showOptionsType: true,
   optional: false,
   showSelectedLabel: true,
-  acceptUserInput: false
+  acceptUserInput: false,
+  customOptionsWidth: ''
 })
 
 const emit = defineEmits(['update:modelValue'])
@@ -355,7 +357,11 @@ onClickOutside(comboboxRef, () => onClickOutsideCombobox())
           <ComboboxOptions
             v-if="filteredOptions.length > 0"
             static
-            class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-gray-200 focus:outline-hidden sm:text-sm dark:bg-gray-950 dark:ring-gray-700"
+            :style="{ width: customOptionsWidth }"
+            :class="[
+              'absolute z-10 mt-1 max-h-60 overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-gray-200 focus:outline-hidden sm:text-sm dark:bg-gray-950 dark:ring-gray-700',
+              !customOptionsWidth && 'w-full'
+            ]"
           >
             <ComboboxOption
               v-for="option in filteredOptions"

--- a/stories/NeCombobox.stories.ts
+++ b/stories/NeCombobox.stories.ts
@@ -252,3 +252,34 @@ export const AcceptUserInputMultiple: Story = {
   }),
   args: { acceptUserInput: true, multiple: true, placeholder: 'Choose or type any fruit' }
 }
+
+export const CustomOptionsWidth: Story = {
+  render: (args) => ({
+    components: { NeCombobox },
+    setup() {
+      return { args }
+    },
+    template: template
+  }),
+  args: {
+    label: 'Choose',
+    customOptionsWidth: '42rem',
+    options: [
+      {
+        id: '1',
+        label: 'This is a very long option text that would normally overflow the combobox width',
+        description: 'Description that is also quite long'
+      },
+      {
+        id: '2',
+        label: 'Another lengthy option with extensive information',
+        description: 'More details about this option'
+      },
+      {
+        id: '3',
+        label: 'Yet another option with a very long descriptive text',
+        description: 'Additional context and information'
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This pull request adds a new feature to the `NeCombobox` component, allowing the width of the dropdown options panel to be customized via a new `customOptionsWidth` prop. The default behavior is preserved, but consumers can now specify a custom width when needed. Additionally, a new story is added to showcase this feature.

**Feature: Customizable options panel width**

* Added an optional `customOptionsWidth` prop to the `NeCombobox` component API, allowing users to specify a custom width for the dropdown options panel.
* Updated the default props and styling logic to use the `customOptionsWidth` value if provided, or fall back to the default full width. [[1]](diffhunk://#diff-e7d720c4e06a5b8b0c1481ac6033f9e8eabfd196f2ec7ddf9c2b0345e96adfc4L71-R73) [[2]](diffhunk://#diff-e7d720c4e06a5b8b0c1481ac6033f9e8eabfd196f2ec7ddf9c2b0345e96adfc4L358-R364)

**Documentation & Examples**

* Added a new `CustomOptionsWidth` story in `NeCombobox.stories.ts` to demonstrate and test the custom width feature with long option labels.