### PR TITLE
build(playground): add component playground app

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "format-fix": "prettier --write src/",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "build-pack": "npm version patch --no-git-tag-version && npm run build && npm pack"
+    "build-pack": "npm version patch --no-git-tag-version && npm run build && npm pack",
+    "playground": "vite --config playground/vite.config.ts"
   },
   "dependencies": {
     "@fontsource/poppins": "^5.2.6",

--- a/playground/App.vue
+++ b/playground/App.vue
@@ -1,0 +1,28 @@
+<script lang="ts" setup>
+import { useDark } from '@vueuse/core'
+import NeButton from '../src/components/NeButton.vue'
+import NeToggle from '../src/components/NeToggle.vue'
+
+const isDark = useDark()
+</script>
+
+<template>
+  <div
+    class="min-h-screen bg-gray-50 p-10 text-sm text-gray-700 dark:bg-gray-900 dark:text-gray-100"
+  >
+    <div class="mb-6 flex items-center justify-between">
+      <h1 class="text-2xl font-semibold">@nethesis/vue-components playground</h1>
+      <NeToggle v-model="isDark" label="Dark mode" />
+    </div>
+
+    <p class="mb-8 max-w-2xl text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+      This playground serves as an interactive testing ground for the Nethesis Vue components
+      library. It's designed to facilitate development and debugging by allowing you to quickly set
+      up test scenarios. Use this space to experiment with components and validate behavior across
+      different configurations.
+    </p>
+
+    <!-- Add components below -->
+    <NeButton kind="primary">Hello from playground</NeButton>
+  </div>
+</template>

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Playground</title>
+    <script>
+      // Prevent FontAwesome from auto-injecting its CSS, since it is imported
+      // manually in main.css via @import layer(vendor) for Tailwind v4 compatibility.
+      // Mirrors the setup in .storybook/preview-head.html.
+      FontAwesomeConfig = { autoAddCss: false }
+    </script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+// playground.css is inside the playground root so @tailwindcss/vite processes
+// it correctly, picking up @import 'tailwindcss' and @theme from main.css.
+import './playground.css'
+
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/playground/playground.css
+++ b/playground/playground.css
@@ -1,0 +1,8 @@
+/* CSS entry point for the playground.
+   Placing this file inside the playground root ensures @tailwindcss/vite
+   processes it (and therefore the @import 'tailwindcss' + @theme directives
+   inside main.css) from within the correct root context.
+   @source explicitly adds the library component files to Tailwind's scan. */
+@import '../src/main.css';
+@source '../src/**/*.vue';
+@source '../src/**/*.ts';

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  root: resolve(__dirname, '.'),
+  plugins: [vue(), tailwindcss()]
+})


### PR DESCRIPTION
This pull request introduces a new local playground environment for the Vue components library, allowing developers to interactively test and develop components outside of Storybook. It adds a Vite-powered playground setup, associated configuration, and a sample usage of core components with dark mode support.

Playground environment setup:

* Added a new `playground` directory with a Vite config (`vite.config.ts`), entry HTML (`index.html`), main entry script (`main.ts`), and a dedicated CSS entry point (`playground.css`). This setup enables fast local development and testing of the component library in isolation. [[1]](diffhunk://#diff-ae1897249ca83a6393a91971111e48e87c641e055d125c3441fd3079e363e311R1-R9) [[2]](diffhunk://#diff-71c326312cbb9acee9247c5898197ab83ddd69d092d121e77450006bed7ed9c4R1-R18) [[3]](diffhunk://#diff-b6e6fef288e9661a8b3bb8eafb9df5e8273e1f64c276db4b6a70b1cd9499f543R1-R10) [[4]](diffhunk://#diff-6e85f3b4c352d45d0cd2f93a7817c4b179478989b248a34775ed6b33e12d383fR1-R8)

Sample usage and features:

* Created `App.vue` in the playground to showcase usage of `NeButton` and `NeToggle` components, including integration with dark mode toggling using `@vueuse/core`. This provides an initial example for interactive testing.

Developer experience improvements:

* Added a new `playground` script to `package.json` to quickly launch the playground environment using Vite.