### PR TITLE
feat: dropdown filter selection pinning, date/time helpers & more

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
         "lodash-es": "^4.17.21",
-        "uuid": "^11.0.0",
         "vue": "^3.5.12",
         "vue-tippy": "^6.3.1"
       },
@@ -32,7 +31,6 @@
         "@tsconfig/node24": "^24.0.0",
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^22.13.4",
-        "@types/uuid": "^11.0.0",
         "@vitejs/plugin-vue": "^5.1.4",
         "@vue/eslint-config-prettier": "^10.0.0",
         "@vue/eslint-config-typescript": "^14.1.1",
@@ -1962,17 +1960,6 @@
       "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
       }
     },
     "node_modules/@types/web-bluetooth": {
@@ -6422,19 +6409,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/vite": {
       "version": "6.4.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "lodash-es": "^4.17.21",
-    "uuid": "^11.0.0",
     "vue": "^3.5.12",
     "vue-tippy": "^6.3.1"
   },
@@ -77,7 +76,6 @@
     "@tsconfig/node24": "^24.0.0",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.13.4",
-    "@types/uuid": "^11.0.0",
     "@vitejs/plugin-vue": "^5.1.4",
     "@vue/eslint-config-prettier": "^10.0.0",
     "@vue/eslint-config-typescript": "^14.1.1",

--- a/src/components/NeCheckbox.vue
+++ b/src/components/NeCheckbox.vue
@@ -4,8 +4,7 @@
 -->
 
 <script lang="ts" setup>
-import { computed } from 'vue'
-import { v4 as uuidv4 } from 'uuid'
+import { computed, useId } from 'vue'
 
 const props = defineProps({
   modelValue: {
@@ -36,7 +35,8 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue'])
 
-const componentId = computed(() => (props.id ? props.id : uuidv4()))
+const generatedId = useId()
+const componentId = computed(() => (props.id ? props.id : generatedId))
 
 const model = computed({
   get() {

--- a/src/components/NeCombobox.vue
+++ b/src/components/NeCombobox.vue
@@ -62,6 +62,14 @@ export interface Props {
   customOptionsWidth?: string
   externalFilter?: boolean
   loadingOptions?: boolean
+  /**
+   * The currently selected option, supplied by the parent. Used to render the
+   * selection when `modelValue`'s option is absent from `options` — the case
+   * `externalFilter` creates, where the parent only supplies a page of a larger
+   * server-side result set. Ignored unless its `id` matches `modelValue`.
+   * Single selection only: in multiple mode `modelValue` already carries options.
+   */
+  selectedOption?: NeComboboxOption
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -79,7 +87,8 @@ const props = withDefaults(defineProps<Props>(), {
   acceptUserInput: false,
   customOptionsWidth: '',
   externalFilter: false,
-  loadingOptions: false
+  loadingOptions: false,
+  selectedOption: undefined
 })
 
 const emit = defineEmits(['update:modelValue', 'filter'])
@@ -252,8 +261,10 @@ onMounted(() => {
   }
 })
 
+// selectedOption is watched alongside modelValue because the two can arrive in
+// separate ticks (e.g. the parent sets the id first and resolves the entity later)
 watch(
-  () => props.modelValue,
+  [() => props.modelValue, () => props.selectedOption],
   () => {
     // don't update selection while user is actively filtering with external filter
     if (props.externalFilter && showOptions.value) {
@@ -379,6 +390,11 @@ function selectSingleOptionFromModelValue() {
 
   if (optionFound) {
     selected.value = optionFound
+  } else if (props.selectedOption && props.selectedOption.id === props.modelValue) {
+    // the option for modelValue isn't in the current page of options, so fall
+    // back to the one the parent supplied. Checking the id keeps a stale prop
+    // from displaying the wrong label after the user picks something else.
+    selected.value = props.selectedOption
   } else if (props.acceptUserInput && props.modelValue) {
     const userInputOption = {
       id: props.modelValue as string,
@@ -563,14 +579,14 @@ onClickOutside(comboboxRef, () => onClickOutsideCombobox())
           selectedLabel
         }}</span>
         <NeBadge
-          v-for="selectedOption in selected"
-          :key="selectedOption.id"
+          v-for="selectedItem in selected"
+          :key="selectedItem.id"
           kind="primary"
-          :text="selectedOption.label"
+          :text="selectedItem.label"
           :icon="fasXmark"
           icon-position="right"
           icon-clickable
-          @icon-click="removeFromSelection(selectedOption)"
+          @icon-click="removeFromSelection(selectedItem)"
         />
       </div>
       <!-- invalid message -->

--- a/src/components/NeCombobox.vue
+++ b/src/components/NeCombobox.vue
@@ -263,21 +263,18 @@ onMounted(() => {
 
 // selectedOption is watched alongside modelValue because the two can arrive in
 // separate ticks (e.g. the parent sets the id first and resolves the entity later)
-watch(
-  [() => props.modelValue, () => props.selectedOption],
-  () => {
-    // don't update selection while user is actively filtering with external filter
-    if (props.externalFilter && showOptions.value) {
-      return
-    }
-
-    if (props.multiple) {
-      selectMultipleOptionsFromModelValue()
-    } else {
-      selectSingleOptionFromModelValue()
-    }
+watch([() => props.modelValue, () => props.selectedOption], () => {
+  // don't update selection while user is actively filtering with external filter
+  if (props.externalFilter && showOptions.value) {
+    return
   }
-)
+
+  if (props.multiple) {
+    selectMultipleOptionsFromModelValue()
+  } else {
+    selectSingleOptionFromModelValue()
+  }
+})
 
 function getLimitedNumberOfOptions(options: NeComboboxOption[]) {
   if (!options.length && !props.acceptUserInput) {

--- a/src/components/NeDropdownFilter.vue
+++ b/src/components/NeDropdownFilter.vue
@@ -4,12 +4,11 @@
 -->
 
 <script setup lang="ts">
-import { ref, watch, computed, onMounted } from 'vue'
+import { ref, watch, computed, onMounted, useId } from 'vue'
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
 import { isEqual } from 'lodash-es'
-import { v4 as uuidv4 } from 'uuid'
 import NeBadgeV2 from './NeBadgeV2.vue'
 import NeLink from './NeLink.vue'
 import NeSkeleton from './NeSkeleton.vue'
@@ -110,7 +109,8 @@ const buttonRef = ref()
 const optionsFilter = ref('')
 const optionsFilterRef = ref()
 
-const componentId = computed(() => (props.id ? props.id : uuidv4()))
+const generatedId = useId()
+const componentId = computed(() => (props.id ? props.id : generatedId))
 
 const isSelectionCountShown = computed(() => {
   return props.showSelectionCount && props.kind == 'checkbox' && checkboxModel.value.length > 0

--- a/src/components/NeDropdownFilterV2.vue
+++ b/src/components/NeDropdownFilterV2.vue
@@ -142,23 +142,22 @@ const filteredOptions = computed((): T[] => {
     return allFlatOptions.value
   }
 
-  const regex = /[^a-zA-Z0-9-]/g
-  const queryText = optionsFilter.value.replace(regex, '')
+  const queryText = normalizeSearchText(optionsFilter.value)
 
   // build a set of matching option IDs, also matching group names
   const matchingIds = new Set<string>()
 
   for (const entry of props.options) {
     if (isFilterOptionGroup(entry)) {
-      const groupMatches = new RegExp(queryText, 'i').test(entry.group?.replace(regex, ''))
+      const groupMatches = matchesSearchQuery(entry.group, queryText)
 
       for (const opt of entry.options) {
-        if (groupMatches || new RegExp(queryText, 'i').test(opt.label?.replace(regex, ''))) {
+        if (groupMatches || optionMatchesSearchQuery(opt, queryText)) {
           matchingIds.add(opt.id)
         }
       }
     } else {
-      if (new RegExp(queryText, 'i').test(entry.label?.replace(regex, ''))) {
+      if (optionMatchesSearchQuery(entry, queryText)) {
         matchingIds.add(entry.id)
       }
     }
@@ -170,7 +169,7 @@ const filteredOptions = computed((): T[] => {
 // Pinned selections still matching the search query. Options coming from props.options
 // reuse the filteredOptions result (so a group name match keeps them, and with
 // externalFilter the caller's own filtering wins); selections that are not part of
-// props.options are matched on their label
+// props.options are matched on their label and description
 const visiblePinnedOptions = computed((): T[] => {
   if (!optionsFilter.value || !isShowingOptionsFilter.value) {
     return selectionSnapshot.value
@@ -178,13 +177,10 @@ const visiblePinnedOptions = computed((): T[] => {
 
   const filteredIds = new Set(filteredOptions.value.map((o) => o.id))
   const knownIds = new Set(allFlatOptions.value.map((o) => o.id))
-  const regex = /[^a-zA-Z0-9-]/g
-  const queryText = optionsFilter.value.replace(regex, '')
+  const queryText = normalizeSearchText(optionsFilter.value)
 
   return selectionSnapshot.value.filter((o) =>
-    knownIds.has(o.id)
-      ? filteredIds.has(o.id)
-      : new RegExp(queryText, 'i').test(o.label?.replace(regex, ''))
+    knownIds.has(o.id) ? filteredIds.has(o.id) : optionMatchesSearchQuery(o, queryText)
   )
 })
 
@@ -322,6 +318,25 @@ watch(
   },
   { immediate: true }
 )
+
+// Strip characters that shouldn't take part in the search (spaces, punctuation, ...), so
+// that the query matches regardless of them and is safe to use as a regular expression
+function normalizeSearchText(text?: string): string {
+  return text?.replace(/[^a-zA-Z0-9-]/g, '') ?? ''
+}
+
+// Case insensitive match of an already normalized query against a text
+function matchesSearchQuery(text: string | undefined, normalizedQuery: string): boolean {
+  return new RegExp(normalizedQuery, 'i').test(normalizeSearchText(text))
+}
+
+// An option matches when the query is found in its label or in its description
+function optionMatchesSearchQuery(option: T, normalizedQuery: string): boolean {
+  return (
+    matchesSearchQuery(option.label, normalizedQuery) ||
+    matchesSearchQuery(option.description, normalizedQuery)
+  )
+}
 
 // Options whose id contains 'divider' are rendered as a separator, not as an option
 function isDivider(item: T | NeDropdownFilterV2OptionGroup<T>): boolean {

--- a/src/components/NeDropdownFilterV2.vue
+++ b/src/components/NeDropdownFilterV2.vue
@@ -4,7 +4,7 @@
 -->
 
 <script setup lang="ts" generic="T extends NeDropdownFilterV2Option = NeDropdownFilterV2Option">
-import { ref, watch, computed, useId } from 'vue'
+import { ref, shallowRef, watch, computed, useId } from 'vue'
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
@@ -91,6 +91,9 @@ const emit = defineEmits<{
 const model = defineModel<T[]>({ default: () => [] })
 const radioModel = ref('')
 const checkboxModel = ref<string[]>([])
+// selected options hoisted to the top of the list, frozen while the menu is open
+const selectionSnapshot = shallowRef<T[]>([])
+const isMenuOpen = ref(false)
 const top = ref(0)
 const left = ref(0)
 const right = ref(0)
@@ -164,16 +167,41 @@ const filteredOptions = computed((): T[] => {
   return allFlatOptions.value.filter((opt) => matchingIds.has(opt.id))
 })
 
-// True when hit maxOptionsShown limit
-const moreOptionsHidden = computed(() => {
-  return filteredOptions.value.length >= props.maxOptionsShown
+// Pinned selections still matching the search query. Options coming from props.options
+// reuse the filteredOptions result (so a group name match keeps them, and with
+// externalFilter the caller's own filtering wins); selections that are not part of
+// props.options are matched on their label
+const visiblePinnedOptions = computed((): T[] => {
+  if (!optionsFilter.value || !isShowingOptionsFilter.value) {
+    return selectionSnapshot.value
+  }
+
+  const filteredIds = new Set(filteredOptions.value.map((o) => o.id))
+  const knownIds = new Set(allFlatOptions.value.map((o) => o.id))
+  const regex = /[^a-zA-Z0-9-]/g
+  const queryText = optionsFilter.value.replace(regex, '')
+
+  return selectionSnapshot.value.filter((o) =>
+    knownIds.has(o.id)
+      ? filteredIds.has(o.id)
+      : new RegExp(queryText, 'i').test(o.label?.replace(regex, ''))
+  )
 })
 
-// Build list with group headers + options, respecting maxOptionsShown
+// Pinned selections consume the maxOptionsShown budget first, so the total number of
+// rendered options never exceeds it
+const pinnedItems = computed((): T[] => {
+  return visiblePinnedOptions.value.slice(0, props.maxOptionsShown)
+})
+
+// Build list with group headers + options, respecting the remaining maxOptionsShown budget.
+// Pinned selections are skipped here to avoid rendering an option twice
 const displayItems = computed(() => {
   const filteredSet = new Set(filteredOptions.value.map((o) => o.id))
+  const pinnedIds = new Set(selectionSnapshot.value.map((o) => o.id))
+  const maxOptions = props.maxOptionsShown - pinnedItems.value.length
   const items: {
-    type: 'group' | 'option'
+    type: 'group' | 'option' | 'divider'
     label?: string
     option?: T
     key: string
@@ -181,31 +209,42 @@ const displayItems = computed(() => {
   let optionCount = 0
 
   for (const entry of props.options) {
-    if (optionCount >= props.maxOptionsShown) break
+    if (optionCount >= maxOptions) break
 
     if (isFilterOptionGroup(entry)) {
-      const visibleOptions = entry.options.filter((o) => filteredSet.has(o.id))
+      const visibleOptions = entry.options.filter(
+        (o) => filteredSet.has(o.id) && !pinnedIds.has(o.id)
+      )
       if (visibleOptions.length === 0) continue
 
       items.push({ type: 'group', label: entry.group, key: `group-${entry.group}` })
       for (const opt of visibleOptions) {
-        if (optionCount >= props.maxOptionsShown) break
+        if (optionCount >= maxOptions) break
+        if (isDivider(opt)) {
+          items.push({ type: 'divider', key: opt.id })
+          continue
+        }
         items.push({ type: 'option', option: opt, key: opt.id })
         optionCount++
       }
+    } else if (isDivider(entry)) {
+      // dividers are not options: they don't consume the maxOptionsShown budget
+      items.push({ type: 'divider', key: entry.id })
     } else {
-      if (!filteredSet.has(entry.id)) continue
+      if (!filteredSet.has(entry.id) || pinnedIds.has(entry.id)) continue
       items.push({ type: 'option', option: entry, key: entry.id })
       optionCount++
     }
   }
 
-  // remove trailing group headers with no options after them
-  while (items.length > 0 && items[items.length - 1].type === 'group') {
+  // drop group headers and dividers that ended up with no option after them, as well as
+  // leading and repeated dividers (e.g. when the options around them are pinned or filtered out)
+  while (items.length > 0 && items[items.length - 1].type !== 'option') {
     items.pop()
   }
-
-  return items
+  return items.filter(
+    (item, index) => item.type !== 'divider' || items[index - 1]?.type === 'option'
+  )
 })
 
 // IDs of options visible after filter + limit (not pinned)
@@ -215,26 +254,18 @@ const displayedOptionIds = computed(() => {
   )
 })
 
-// Selected options not in display list (hidden by filter/limit). Pin at top so always visible
-const pinnedOptions = computed((): T[] => {
-  let candidates = (model.value ?? []).filter((o) => !displayedOptionIds.value.has(o.id))
-
-  // hide pinned options that don't match the search query (also when filtering
-  // externally, so that only matching options are shown while searching)
-  if (isShowingOptionsFilter.value && optionsFilter.value) {
-    const regex = /[^a-zA-Z0-9-]/g
-    const queryText = optionsFilter.value.replace(regex, '')
-    candidates = candidates.filter((o) =>
-      new RegExp(queryText, 'i').test(o.label?.replace(regex, ''))
-    )
-  }
-
-  return candidates
+// True when some options matching the current filter are left out of the rendered list
+const moreOptionsHidden = computed(() => {
+  const shownIds = new Set([...pinnedItems.value.map((o) => o.id), ...displayedOptionIds.value])
+  return (
+    pinnedItems.value.length < visiblePinnedOptions.value.length ||
+    filteredOptions.value.some((o) => !isDivider(o) && !shownIds.has(o.id))
+  )
 })
 
 // Render order: pinned selections first, then limited display list
 const renderItems = computed(() => {
-  const pinned = pinnedOptions.value.map((option) => ({
+  const pinned = pinnedItems.value.map((option) => ({
     type: 'option' as const,
     option,
     key: `pinned-${option.id}`
@@ -280,6 +311,23 @@ watch(optionsFilter, (query) => {
   emit('search', query)
 })
 
+// Keep the selection snapshot up to date while the menu is closed, so that selected
+// options are hoisted to the top only when the menu is (re)opened
+watch(
+  [() => model.value, () => props.options],
+  () => {
+    if (!isMenuOpen.value) {
+      snapshotSelection()
+    }
+  },
+  { immediate: true }
+)
+
+// Options whose id contains 'divider' are rendered as a separator, not as an option
+function isDivider(item: T | NeDropdownFilterV2OptionGroup<T>): boolean {
+  return !isFilterOptionGroup(item) && item.id.includes('divider')
+}
+
 function isFilterOptionGroup(
   item: T | NeDropdownFilterV2OptionGroup<T>
 ): item is NeDropdownFilterV2OptionGroup<T> {
@@ -298,6 +346,29 @@ function updateInternalModel() {
       checkboxModel.value = modelIds
     }
   }
+}
+
+// Take a snapshot of the current selection, ordered as in the options list. Selections
+// missing from props.options (e.g. when filtering externally) are appended at the end
+function snapshotSelection() {
+  const selected = model.value ?? []
+  const selectedIds = new Set(selected.map((o) => o.id))
+  const inOptionsOrder = allFlatOptions.value.filter((o) => selectedIds.has(o.id))
+  const knownIds = new Set(inOptionsOrder.map((o) => o.id))
+  selectionSnapshot.value = [...inOptionsOrder, ...selected.filter((o) => !knownIds.has(o.id))]
+}
+
+// The transition hooks are used instead of the button click because Headless UI opens the
+// menu on Enter/Space without emitting a click event
+function onMenuOpen() {
+  isMenuOpen.value = true
+  snapshotSelection()
+}
+
+function onMenuClose() {
+  isMenuOpen.value = false
+  clearOptionsFilter()
+  snapshotSelection()
 }
 
 function calculatePosition() {
@@ -363,8 +434,9 @@ function clearFilter() {
         leave-active-class="transition ease-in duration-75"
         leave-from-class="transform opacity-100 scale-100"
         leave-to-class="transform opacity-0 scale-95"
+        @before-enter="onMenuOpen"
         @after-enter="maybeFocusOptionsFilter"
-        @after-leave="clearOptionsFilter"
+        @after-leave="onMenuClose"
       >
         <MenuItems
           :style="[
@@ -407,13 +479,13 @@ function clearFilter() {
             >
               {{ item.label }}
             </div>
+            <!-- divider -->
+            <hr
+              v-else-if="item.type === 'divider'"
+              class="my-1 border-gray-200 dark:border-gray-700"
+            />
             <!-- option -->
             <MenuItem v-else as="div" :disabled="item.option?.disabled">
-              <!-- divider -->
-              <hr
-                v-if="item.option?.id.includes('divider')"
-                class="my-1 border-gray-200 dark:border-gray-700"
-              />
               <!-- radio option -->
               <div v-if="kind === 'radio'" class="flex items-center py-2">
                 <input
@@ -482,7 +554,7 @@ function clearFilter() {
             {{ moreOptionsHiddenLabel }}
           </div>
           <!-- no option matching filter -->
-          <div v-if="!loadingOptions && !filteredOptions.length && !pinnedOptions.length">
+          <div v-if="!loadingOptions && !renderItems.length">
             <div class="py-2 text-gray-500 dark:text-gray-400">
               {{ noOptionsLabel }}
             </div>

--- a/src/components/NeDropdownFilterV2.vue
+++ b/src/components/NeDropdownFilterV2.vue
@@ -430,12 +430,16 @@ function clearFilter() {
           <span class="flex items-center justify-center">
             <slot v-if="$slots.label" name="label"></slot>
             <span v-else>{{ label }}</span>
-            <NeBadgeV2 v-if="isSelectionCountShown" size="xs" class="ml-2">{{
+            <NeBadgeV2 v-if="isSelectionCountShown" size="xs" kind="indigo" class="ml-2">{{
               checkboxModel.length
             }}</NeBadgeV2>
-            <NeBadgeV2 v-else-if="currentRadioSelectionLabel" size="xs" class="ml-2">{{
-              currentRadioSelectionLabel
-            }}</NeBadgeV2>
+            <NeBadgeV2
+              v-else-if="currentRadioSelectionLabel"
+              size="xs"
+              kind="indigo"
+              class="ml-2"
+              >{{ currentRadioSelectionLabel }}</NeBadgeV2
+            >
             <FontAwesomeIcon :icon="faChevronDown" class="ml-2 h-3 w-3" aria-hidden="true" />
           </span>
         </button>

--- a/src/components/NeModal.vue
+++ b/src/components/NeModal.vue
@@ -8,7 +8,7 @@ import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } fro
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import NeButton, { type ButtonKind } from './NeButton.vue'
 import NeRoundedIcon from './NeRoundedIcon.vue'
-import { watch } from 'vue'
+import { computed, watch } from 'vue'
 import { faXmark } from '@fortawesome/free-solid-svg-icons'
 
 export type ModalKind = 'neutral' | 'info' | 'warning' | 'error' | 'success'
@@ -47,6 +47,9 @@ const {
 }>()
 
 const emit = defineEmits(['close', 'primaryClick', 'secondaryClick', 'show'])
+
+// when all three buttons are shown, cancel is moved to the opposite side of the footer
+const cancelOnLeft = computed(() => Boolean(primaryLabel && secondaryLabel && cancelLabel))
 
 const sizeStyle: Record<ModalSize, string> = {
   md: 'sm:max-w-lg',
@@ -165,7 +168,7 @@ function onSecondaryClick() {
                     v-if="cancelLabel"
                     kind="tertiary"
                     size="lg"
-                    class="mt-3 w-full sm:mt-0 sm:w-auto"
+                    :class="['mt-3 w-full sm:mt-0 sm:w-auto', cancelOnLeft ? 'sm:mr-auto' : '']"
                     @click="onClose"
                     >{{ cancelLabel }}</NeButton
                   >

--- a/src/components/NePaginator.vue
+++ b/src/components/NePaginator.vue
@@ -4,7 +4,7 @@
 -->
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, useId, watch } from 'vue'
 import { range } from 'lodash-es'
 import { faChevronLeft as fasChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { faChevronRight as fasChevronRight } from '@fortawesome/free-solid-svg-icons'
@@ -58,6 +58,8 @@ const emit = defineEmits<{
   selectPage: [page: number]
   selectPageSize: [pageSize: number]
 }>()
+
+const pageSizeLabelId = useId()
 
 const internalPageSize = ref('')
 
@@ -133,13 +135,13 @@ function navigateToPage(page: number) {
       <div>{{ firstRow }} - {{ lastRow }} {{ rangeOfTotalLabel }} {{ totalRows }}</div>
 
       <div class="flex items-center gap-2">
-        <div id="page-size-label">{{ pageSizeLabel }}</div>
+        <div :id="pageSizeLabelId">{{ pageSizeLabel }}</div>
         <NeListbox
           v-model="internalPageSize"
           :options="pageSizeOptions"
           no-options-label=""
           optional-label=""
-          aria-labelledby="page-size-label"
+          :aria-labelledby="pageSizeLabelId"
           :options-panel-style="listboxOptionsPanelStyle"
         />
       </div>

--- a/src/components/NeRadioSelection.vue
+++ b/src/components/NeRadioSelection.vue
@@ -16,11 +16,10 @@ export type RadioOption = {
 </script>
 
 <script lang="ts" setup generic="T extends RadioOption">
-import { computed, type PropType, type Ref, ref, watch } from 'vue'
+import { computed, type PropType, type Ref, ref, useId, watch } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons'
 import NeFormItemLabel from './NeFormItemLabel.vue'
-import { v4 as uuidv4 } from 'uuid'
 
 export type RadioCardSize = 'md' | 'lg' | 'xl'
 
@@ -107,7 +106,8 @@ const selectionMarkClasses: Record<RadioCardSize, string> = {
   xl: 'right-3 top-3 h-5 w-5'
 }
 
-const radioName = computed(() => (props.name ? props.name : uuidv4()))
+const generatedName = useId()
+const radioName = computed(() => (props.name ? props.name : generatedName))
 
 watch(value, (newValue) => emit('update:modelValue', newValue))
 

--- a/src/components/NeRoundedIcon.vue
+++ b/src/components/NeRoundedIcon.vue
@@ -13,7 +13,7 @@ import {
   type IconDefinition
 } from '@fortawesome/free-solid-svg-icons'
 
-type RoundedIconKind = 'info' | 'warning' | 'error' | 'success'
+export type RoundedIconKind = 'info' | 'warning' | 'error' | 'success' | 'gray'
 
 interface RoundedIconProps {
   kind?: RoundedIconKind
@@ -24,7 +24,8 @@ interface RoundedIconProps {
 
 const props = defineProps<RoundedIconProps>()
 
-const iconName: Record<RoundedIconKind, IconDefinition> = {
+// the 'gray' kind has no standard icon: it is always paired with customIcon
+const iconName: Partial<Record<RoundedIconKind, IconDefinition>> = {
   info: faCircleInfo,
   warning: faTriangleExclamation,
   error: faCircleXmark,
@@ -35,21 +36,28 @@ const iconBackgroundStyle: Record<RoundedIconKind, string> = {
   info: 'bg-blue-100 dark:bg-blue-800',
   warning: 'bg-amber-100 dark:bg-amber-800',
   error: 'bg-rose-100 dark:bg-rose-800',
-  success: 'bg-green-100 dark:bg-green-800'
+  success: 'bg-green-100 dark:bg-green-800',
+  gray: 'bg-gray-100 dark:bg-gray-800'
 }
 
 const iconForegroundStyle: Record<RoundedIconKind, string> = {
   info: 'text-blue-700 dark:text-blue-50',
   warning: 'text-amber-700 dark:text-amber-50',
   error: 'text-rose-700 dark:text-rose-50',
-  success: 'text-green-700 dark:text-green-50'
+  success: 'text-green-700 dark:text-green-50',
+  gray: 'text-gray-700 dark:text-gray-50'
 }
 
 function getIcon(): IconDefinition | Array<string> {
-  if (props.kind) {
-    return iconName[props.kind]
-  } else if (props.customIcon) {
-    return props.customIcon
+  // customIcon takes precedence over the kind default, so that kinds without a
+  // standard icon (e.g. 'gray') can be paired with any icon. An empty array is
+  // treated as "not set", since it's the idiomatic empty value for icon props.
+  const customIcon = props.customIcon
+
+  if (customIcon != null && !(Array.isArray(customIcon) && customIcon.length === 0)) {
+    return customIcon
+  } else if (props.kind) {
+    return iconName[props.kind] ?? []
   } else {
     return []
   }

--- a/src/components/NeSortDropdown.vue
+++ b/src/components/NeSortDropdown.vue
@@ -4,11 +4,10 @@
 -->
 
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed, useId } from 'vue'
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
-import { v4 as uuidv4 } from 'uuid'
 import type { ButtonSize } from './NeButton.vue'
 
 export type SortOption = {
@@ -54,7 +53,8 @@ const left = ref(0)
 const right = ref(0)
 const buttonRef = ref()
 
-const componentId = computed(() => (props.id ? props.id : uuidv4()))
+const generatedId = useId()
+const componentId = computed(() => (props.id ? props.id : generatedId))
 
 watch(
   () => props.alignToRight,

--- a/src/components/NeTabs.vue
+++ b/src/components/NeTabs.vue
@@ -4,7 +4,7 @@
 -->
 
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, useId, watch } from 'vue'
 
 export interface Tab {
   name: string
@@ -24,6 +24,8 @@ const props = withDefaults(defineProps<Props>(), {
   srSelectTabLabel: 'Select a tab',
   srTabsLabel: 'Tabs'
 })
+
+const selectId = useId()
 
 const currentTab = ref('')
 
@@ -66,9 +68,9 @@ const emit = defineEmits(['selectTab'])
   <div>
     <!-- mobile tabs -->
     <div class="sm:hidden">
-      <label for="tabs_select" class="sr-only">{{ srSelectTabLabel }}</label>
+      <label :for="selectId" class="sr-only">{{ srSelectTabLabel }}</label>
       <select
-        id="tabs_select"
+        :id="selectId"
         v-model="currentTab"
         name="tabs_select"
         class="focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-md border-gray-300 bg-white py-2 pr-10 pl-3 text-base text-gray-700 focus:outline-hidden sm:text-sm dark:border-gray-700 dark:bg-gray-950 dark:text-gray-50"

--- a/src/components/NeTextArea.vue
+++ b/src/components/NeTextArea.vue
@@ -4,8 +4,7 @@
 -->
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import { v4 as uuidv4 } from 'uuid'
+import { computed, ref, useId } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCircleExclamation as fasCircleExclamation } from '@fortawesome/free-solid-svg-icons'
@@ -79,7 +78,8 @@ const textAreaWritableStyle = 'bg-white dark:bg-gray-950'
 
 const descriptionBaseStyle = 'mt-2 text-sm'
 
-const componentId = computed(() => (props.id ? props.id : uuidv4()))
+const generatedId = useId()
+const componentId = computed(() => (props.id ? props.id : generatedId))
 
 const textAreaStyles = computed(() =>
   [

--- a/src/components/NeTextInput.vue
+++ b/src/components/NeTextInput.vue
@@ -4,8 +4,7 @@
 -->
 
 <script setup lang="ts">
-import { computed, ref, useAttrs } from 'vue'
-import { v4 as uuidv4 } from 'uuid'
+import { computed, ref, useAttrs, useId } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCircleExclamation as fasCircleExclamation } from '@fortawesome/free-solid-svg-icons'
@@ -106,7 +105,8 @@ const descriptionBaseStyle = 'mt-2 text-sm'
 
 const isPasswordVisible = ref(false)
 
-const componentId = computed(() => (props.id ? props.id : uuidv4()))
+const generatedId = useId()
+const componentId = computed(() => (props.id ? props.id : generatedId))
 
 const inputStyles = computed(() =>
   [

--- a/src/components/NeToastNotificationV2.vue
+++ b/src/components/NeToastNotificationV2.vue
@@ -7,11 +7,11 @@
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faXmark as fasXmark } from '@fortawesome/free-solid-svg-icons'
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { humanDistanceToNowLoc, formatDateLoc } from '../main'
 import NeButton, { type ButtonKind } from './NeButton.vue'
 import NeRoundedIcon from './NeRoundedIcon.vue'
-import NeTooltip from './NeTooltip.vue'
+import NeTooltip, { type TippyComponentProps } from './NeTooltip.vue'
 import { type PropType } from 'vue'
+import { formatDateTimeNoSeconds, formatRelativeTime, getBrowserLocale } from '../lib/dateTime'
 
 export interface NeNotificationV2 {
   id: string
@@ -58,6 +58,14 @@ defineProps({
 
 defineEmits(['close', 'action'])
 
+/**
+ * The timestamp trigger lives inside an absolutely positioned container, which would clip the
+ * tooltip and cap its width. Appending the tooltip to the body avoids both issues.
+ */
+const timestampTippyProps: TippyComponentProps = {
+  appendTo: () => document.body
+}
+
 // add fontawesome icons
 library.add(fasXmark)
 </script>
@@ -87,16 +95,17 @@ library.add(fasXmark)
         <!-- timestamp -->
         <NeTooltip
           v-else-if="showTimestamp && notification.timestamp"
-          placement="left-start"
+          placement="auto"
+          :tippy-props="timestampTippyProps"
           class="text-gray-500 dark:text-gray-400"
         >
           <template #trigger>
             <span class="cursor-pointer">
-              {{ humanDistanceToNowLoc(notification.timestamp) }}
+              {{ formatRelativeTime(notification.timestamp, getBrowserLocale()) }}
             </span>
           </template>
           <template #content>
-            {{ formatDateLoc(notification.timestamp, 'Pp') }}
+            {{ formatDateTimeNoSeconds(notification.timestamp, getBrowserLocale()) }}
           </template>
         </NeTooltip>
       </div>

--- a/src/components/NeTooltip.vue
+++ b/src/components/NeTooltip.vue
@@ -33,6 +33,11 @@ export type TooltipTriggerEvent =
   | 'mouseenter click'
   | 'manual'
 
+/**
+ * All the props accepted by the Tippy component, see https://vue-tippy.netlify.app/props/
+ */
+export type TippyComponentProps = Partial<InstanceType<typeof Tippy>['$props']>
+
 defineProps({
   placement: {
     type: String as PropType<TooltipPlacement>,
@@ -45,12 +50,27 @@ defineProps({
   interactive: {
     type: Boolean,
     default: true
+  },
+  /**
+   * Any additional Tippy prop (https://vue-tippy.netlify.app/props/), e.g.
+   * `{ maxWidth: 'none', offset: [0, 20], delay: [300, 0] }`.
+   * The props above take precedence over the same key set here.
+   */
+  tippyProps: {
+    type: Object as PropType<TippyComponentProps>,
+    default: undefined
   }
 })
 </script>
 
 <template>
-  <Tippy :interactive="interactive" :placement="placement" :trigger="triggerEvent" theme="tailwind">
+  <Tippy
+    v-bind="tippyProps"
+    :interactive="interactive"
+    :placement="placement"
+    :trigger="triggerEvent"
+    theme="tailwind"
+  >
     <slot name="trigger">
       <button type="button" class="inline-flex">
         <FontAwesomeIcon

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -4,17 +4,32 @@
 import { enGB, it } from 'date-fns/locale'
 import { format, utcToZonedTime } from 'date-fns-tz'
 import { formatDistanceToNowStrict, formatDuration, intervalToDuration } from 'date-fns'
+import { capitalizeFirst } from './utils'
+
+const RELATIVE_DIVISIONS: { amount: number; unit: Intl.RelativeTimeFormatUnit }[] = [
+  { amount: 60, unit: 'second' },
+  { amount: 60, unit: 'minute' },
+  { amount: 24, unit: 'hour' },
+  { amount: 7, unit: 'day' },
+  { amount: 4.34524, unit: 'week' },
+  { amount: 12, unit: 'month' },
+  { amount: Number.POSITIVE_INFINITY, unit: 'year' }
+]
 
 /**
  * Format a date expressed in milliseconds to current locale
  *
  */
-export function formatDateLoc(date: any, fmt: string) {
+export function formatDateLoc(date: Date | number, fmt: string) {
   return format(date, fmt, { locale: getDateFnsLocale() })
 }
 
-export const formatInTimeZoneLoc = (date: any, fmt: string, tz: any) => {
+export const formatInTimeZoneLoc = (date: Date | string | number, fmt: string, tz: string) => {
   return format(utcToZonedTime(date, tz), fmt, { timeZone: tz, locale: getDateFnsLocale() })
+}
+
+export const getBrowserLocale = () => {
+  return navigator?.language.substring(0, 2) || 'en'
 }
 
 /**
@@ -23,7 +38,7 @@ export const formatInTimeZoneLoc = (date: any, fmt: string, tz: any) => {
  */
 export const getDateFnsLocale = (localeArg?: string) => {
   let loc = enGB
-  const lang = localeArg || navigator?.language.substring(0, 2)
+  const lang = localeArg || getBrowserLocale()
 
   if (lang) {
     switch (lang) {
@@ -39,10 +54,15 @@ export const getDateFnsLocale = (localeArg?: string) => {
 /**
  * Format a duration expressed in seconds to a human readable value. E.g. 189 -> 3 minutes 9 seconds
  *
- * @param seconds - duration to format
+ * @param durationSeconds - duration to format
+ * @param options - date-fns formatDuration options; 'locale' is always overridden with the current
+ * locale
  *
  */
-export function formatDurationLoc(durationSeconds: number, options: any = {}) {
+export function formatDurationLoc(
+  durationSeconds: number,
+  options: Parameters<typeof formatDuration>[1] = {}
+) {
   if (!durationSeconds) {
     return null
   }
@@ -59,10 +79,183 @@ export function formatDurationLoc(durationSeconds: number, options: any = {}) {
 /**
  * Return the approximate and concise distance from a date to now. Example output: '2 hours'.
  * Useful to show how long ago something has happened (e.g. a notification timestamp)
+ *
+ * @param date - date to compare with now
+ * @param options - date-fns formatDistanceToNowStrict options; 'locale' is always overridden with
+ * the current locale
+ *
+ * @deprecated Use {@link formatRelativeTime} instead: it produces a complete relative time string
+ * (e.g. '2 hours ago', 'Yesterday') instead of a bare distance, and relies on
+ * Intl.RelativeTimeFormat rather than date-fns.
  */
-export function humanDistanceToNowLoc(date: Date, options: any = {}) {
+export function humanDistanceToNowLoc(
+  date: Date,
+  options: Parameters<typeof formatDistanceToNowStrict>[1] = {}
+) {
   if (!date) {
     return null
   }
   return formatDistanceToNowStrict(date, { ...options, locale: getDateFnsLocale() })
+}
+
+/**
+ * Format a date as a relative time string against the current instant, picking the largest
+ * fitting unit (second, minute, hour, day, week, month, year).
+ * Past dates yield e.g. '2 hours ago', future dates 'in 2 hours'; dates within the previous or
+ * next unit yield the idiomatic wording when available (e.g. 'Yesterday', 'Last month').
+ * The result is capitalized.
+ *
+ * Strings are not accepted, because `new Date(string)` parsing is ambiguous. Build the Date at the
+ * call site instead:
+ * - ISO 8601 with 'Z' or an offset is safe and portable: `new Date('2026-07-27T10:00:00Z')`
+ * - epoch seconds: pass the number directly, e.g. `formatRelativeTime(seconds * 1000, locale)`
+ * - no offset ('2026-07-27T10:00:00') is parsed as LOCAL time; append 'Z' if the value is UTC
+ * - date-only ('2026-07-27') is parsed as UTC midnight and can render as the wrong day; for local
+ *   midnight use `new Date(2026, 6, 27)`
+ * - other forms ('2026-07-27 10:00', '27/07/2026') are implementation-defined; do not rely on them
+ *
+ * @param date - date to compare with now, or a timestamp in milliseconds
+ * @param locale - BCP 47 locale tag used by Intl.RelativeTimeFormat (e.g. 'en-GB', 'it')
+ * @returns the formatted relative time, or '-' if the date is missing or invalid
+ *
+ */
+export function formatRelativeTime(date: Date | number, locale: string): string {
+  const validDate = toValidDate(date, 'formatRelativeTime')
+
+  if (!validDate) {
+    return '-'
+  }
+
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+  let duration = (validDate.getTime() - Date.now()) / 1000
+
+  for (const division of RELATIVE_DIVISIONS) {
+    if (Math.abs(duration) < division.amount) {
+      return capitalizeFirst(rtf.format(Math.round(duration), division.unit))
+    }
+    duration /= division.amount
+  }
+
+  return capitalizeFirst(rtf.format(Math.round(duration), 'year'))
+}
+
+/**
+ * Normalize a date input to a valid Date, or null when the value is missing or not a real date.
+ *
+ * Accepts a Date or a timestamp in milliseconds. Strings are intentionally not accepted: parsing
+ * them with `new Date(...)` is ambiguous (e.g. '2026-07-27' is UTC midnight, not local midnight)
+ * and only the caller knows the format. A present but unusable value is reported on the console so
+ * that the '-' rendered by the formatters is debuggable; a missing value is a legitimate absence
+ * and stays silent.
+ *
+ * @param value - value to normalize
+ * @param fnName - name of the calling formatter, used to prefix the console warning
+ * @returns a valid Date, or null if the value is missing or invalid
+ *
+ */
+function toValidDate(value: Date | number | null | undefined, fnName: string): Date | null {
+  if (value == null) {
+    return null
+  }
+  const date = value instanceof Date ? value : new Date(value)
+
+  if (isNaN(date.getTime())) {
+    console.warn(`[${fnName}] received an invalid date, rendering '-':`, value)
+    return null
+  }
+  return date
+}
+
+/**
+ * Build the Intl.DateTimeFormat options needed to render a date in a specific time zone,
+ * including its short time zone name (e.g. 'GMT+2').
+ *
+ * @param timeZone - IANA time zone name (e.g. 'Europe/Rome'); if omitted the local time zone is used
+ * @returns the time zone options, or an empty object when no time zone is given
+ *
+ */
+function getTimeZoneOptions(timeZone?: string): Intl.DateTimeFormatOptions {
+  if (!timeZone) {
+    return {}
+  }
+
+  return {
+    timeZone,
+    timeZoneName: 'short'
+  }
+}
+
+/**
+ * Format a date and time using the locale conventions. Example output: '27/07/2026, 15:30:00'.
+ * When a time zone is provided, the date is converted to it and the short time zone name is
+ * appended (e.g. '27/07/2026, 15:30:00 GMT+2'); otherwise the local time zone is used.
+ *
+ * Strings are not accepted, because `new Date(string)` parsing is ambiguous. Build the Date at the
+ * call site instead:
+ * - ISO 8601 with 'Z' or an offset is safe and portable: `new Date('2026-07-27T10:00:00Z')`
+ * - epoch seconds: pass the number directly, e.g. `formatDateTime(seconds * 1000, locale)`
+ * - no offset ('2026-07-27T10:00:00') is parsed as LOCAL time; append 'Z' if the value is UTC
+ * - date-only ('2026-07-27') is parsed as UTC midnight and can render as the wrong day; for local
+ *   midnight use `new Date(2026, 6, 27)`
+ * - other forms ('2026-07-27 10:00', '27/07/2026') are implementation-defined; do not rely on them
+ *
+ * @param dateTime - date to format, or a timestamp in milliseconds
+ * @param locale - BCP 47 locale tag used by Date.toLocaleString (e.g. 'en-GB', 'it')
+ * @param timeZone - optional IANA time zone name (e.g. 'Europe/Rome')
+ * @returns the formatted date and time, or '-' if the date is missing or invalid
+ *
+ */
+export function formatDateTime(dateTime: Date | number, locale: string, timeZone?: string): string {
+  const validDate = toValidDate(dateTime, 'formatDateTime')
+
+  if (!validDate) {
+    return '-'
+  }
+  const options = getTimeZoneOptions(timeZone)
+
+  return Object.keys(options).length > 0
+    ? validDate.toLocaleString(locale, options)
+    : validDate.toLocaleString(locale)
+}
+
+/**
+ * Format a date and time using the locale conventions, omitting seconds and using an abbreviated
+ * month name. Example output: '27 Jul 2026, 15:30'.
+ * When a time zone is provided, the date is converted to it and the short time zone name is
+ * appended (e.g. '27 Jul 2026, 15:30 GMT+2'); otherwise the local time zone is used.
+ *
+ * Strings are not accepted, because `new Date(string)` parsing is ambiguous. Build the Date at the
+ * call site instead:
+ * - ISO 8601 with 'Z' or an offset is safe and portable: `new Date('2026-07-27T10:00:00Z')`
+ * - epoch seconds: pass the number directly, e.g. `formatDateTimeNoSeconds(seconds * 1000, locale)`
+ * - no offset ('2026-07-27T10:00:00') is parsed as LOCAL time; append 'Z' if the value is UTC
+ * - date-only ('2026-07-27') is parsed as UTC midnight and can render as the wrong day; for local
+ *   midnight use `new Date(2026, 6, 27)`
+ * - other forms ('2026-07-27 10:00', '27/07/2026') are implementation-defined; do not rely on them
+ *
+ * @param dateTime - date to format, or a timestamp in milliseconds
+ * @param locale - BCP 47 locale tag used by Date.toLocaleString (e.g. 'en-GB', 'it')
+ * @param timeZone - optional IANA time zone name (e.g. 'Europe/Rome')
+ * @returns the formatted date and time without seconds, or '-' if the date is missing or invalid
+ *
+ */
+export function formatDateTimeNoSeconds(
+  dateTime: Date | number,
+  locale: string,
+  timeZone?: string
+): string {
+  const validDate = toValidDate(dateTime, 'formatDateTimeNoSeconds')
+
+  if (!validDate) {
+    return '-'
+  }
+
+  return validDate.toLocaleString(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    ...getTimeZoneOptions(timeZone)
+  })
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,14 @@ import { nextTick } from 'vue'
 import type { Ref } from 'vue'
 
 /**
+ * Uppercase the first character, leaving the rest untouched. Unlike lodash capitalize, it doesn't
+ * lowercase the remainder, which would mangle locales that capitalize other words (e.g. German)
+ */
+export function capitalizeFirst(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+/**
  * Sort function to order array elements by a specific property (for array of objects) or by a specific index (for arrays of arrays)
  *
  */

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,7 @@ export type { ModalKind, PrimaryButtonKind, ModalSize } from './components/NeMod
 export type { AvatarSize } from './components/NeAvatar.vue'
 export type { NeNotificationV2 } from './components/NeToastNotificationV2.vue'
 export type { NeBadgeV2Kind } from './components/NeBadgeV2.vue'
+export type { RoundedIconKind } from './components/NeRoundedIcon.vue'
 
 // library functions export
 export {

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,11 @@ export type { AvatarSize } from './components/NeAvatar.vue'
 export type { NeNotificationV2 } from './components/NeToastNotificationV2.vue'
 export type { NeBadgeV2Kind } from './components/NeBadgeV2.vue'
 export type { RoundedIconKind } from './components/NeRoundedIcon.vue'
+export type {
+  TooltipPlacement,
+  TooltipTriggerEvent,
+  TippyComponentProps
+} from './components/NeTooltip.vue'
 
 // library functions export
 export {
@@ -84,15 +89,23 @@ export {
   getAxiosErrorMessage,
   byteFormat1024,
   byteFormat1000,
-  kbpsFormat
+  kbpsFormat,
+  capitalizeFirst
 } from './lib/utils'
 export {
   formatDateLoc,
   formatInTimeZoneLoc,
+  getBrowserLocale,
   getDateFnsLocale,
   formatDurationLoc,
-  humanDistanceToNowLoc
+  formatRelativeTime,
+  formatDateTime,
+  formatDateTimeNoSeconds
 } from './lib/dateTime'
+/**
+ * @deprecated Use formatRelativeTime instead. This function will be removed in a future release.
+ */
+export { humanDistanceToNowLoc } from './lib/dateTime'
 export {
   saveToStorage,
   getJsonFromStorage,

--- a/stories/NeCombobox.stories.ts
+++ b/stories/NeCombobox.stories.ts
@@ -336,6 +336,33 @@ export const ExternalFilter: Story = {
   }
 }
 
+// The selected option is not part of the served page of options — the situation
+// external filtering creates when the parent paginates a larger server-side
+// result set. Without `selectedOption` the field would render empty.
+export const ExternalFilterWithSelectedOption: Story = {
+  render: (args) => ({
+    components: { NeCombobox },
+    setup() {
+      const options = ref([...meta.args.options])
+      const modelValue = ref('99')
+      function onFilter(query: string) {
+        options.value = meta.args.options.filter((opt) =>
+          opt.label.toLowerCase().includes(query.toLowerCase())
+        )
+      }
+      return { args, options, modelValue, onFilter }
+    },
+    template:
+      '<NeCombobox v-bind="args" :options="options" v-model="modelValue" @filter="onFilter" class="max-w-md" />'
+  }),
+  args: {
+    externalFilter: true,
+    label: 'Choose fruit (external filter, selection outside the served page)',
+    placeholder: 'Type to filter...',
+    selectedOption: { id: '99', label: 'Elderberry', description: 'berry' }
+  }
+}
+
 export const ExternalFilterWithUserInput: Story = {
   render: (args) => ({
     components: { NeCombobox },

--- a/stories/NeDropdownFilterV2.stories.ts
+++ b/stories/NeDropdownFilterV2.stories.ts
@@ -119,29 +119,44 @@ export const OptionsWithDescription: Story = {
     template: template
   }),
   args: {
+    // the internal filter searches both labels and descriptions: e.g. typing "backup"
+    // matches "Storage", "certbot" matches "Let's Encrypt", "kb" matches "Documentation"
+    showOptionsFilter: true,
     options: [
       {
         id: 'option1',
-        label: 'Option 1',
-        description: 'Description for option 1',
+        label: 'Storage',
+        description: 'Disks, volumes and backup destinations',
         disabled: false
       },
       {
         id: 'option2',
-        label: 'Option 2',
-        description: 'Description for option 2',
+        label: 'Networking',
+        description: 'Interfaces, DNS zones and firewall rules',
         disabled: false
       },
       {
         id: 'option3',
-        label: 'Option 3',
-        description: 'Description for option 3',
+        label: "Let's Encrypt",
+        description: 'ACME certificates issued via certbot',
         disabled: true
       },
       {
         id: 'option4',
-        label: 'Option 4',
-        description: 'Description for option 4',
+        label: 'Documentation',
+        description: 'Manuals, KB articles & release notes',
+        disabled: false
+      },
+      {
+        id: 'option5',
+        label: 'Monitoring',
+        description: 'Metrics, alerts and Grafana dashboards',
+        disabled: false
+      },
+      {
+        id: 'option6',
+        label: 'Accounts provider',
+        description: 'LDAP / Active Directory user domains',
         disabled: false
       }
     ]

--- a/stories/NeRoundedIcon.stories.ts
+++ b/stories/NeRoundedIcon.stories.ts
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: GPL-3.0-or-later
 
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
-import { faHeart } from '@fortawesome/free-solid-svg-icons'
+import { faHeart, faServer } from '@fortawesome/free-solid-svg-icons'
 import { NeRoundedIcon } from '../src/main'
 
 const meta = {
@@ -10,11 +10,11 @@ const meta = {
   component: NeRoundedIcon,
   tags: ['autodocs'],
   argTypes: {
-    kind: { control: 'inline-radio', options: ['info', 'warning', 'error', 'success'] }
+    kind: { control: 'inline-radio', options: ['info', 'warning', 'error', 'success', 'gray'] }
   },
   args: {
     kind: undefined,
-    customIcon: [],
+    customIcon: undefined,
     customForegroundClasses: '',
     customBackgroundClasses: ''
   }
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof meta>
 
 const template = '<NeRoundedIcon v-bind="args"/>'
 
-export const Kind: Story = {
+export const Info: Story = {
   render: (args) => ({
     components: { NeRoundedIcon },
     setup() {
@@ -34,6 +34,51 @@ export const Kind: Story = {
     template: template
   }),
   args: { kind: 'info' }
+}
+
+export const Warning: Story = {
+  render: (args) => ({
+    components: { NeRoundedIcon },
+    setup() {
+      return { args }
+    },
+    template: template
+  }),
+  args: { kind: 'warning' }
+}
+
+export const Error: Story = {
+  render: (args) => ({
+    components: { NeRoundedIcon },
+    setup() {
+      return { args }
+    },
+    template: template
+  }),
+  args: { kind: 'error' }
+}
+
+export const Success: Story = {
+  render: (args) => ({
+    components: { NeRoundedIcon },
+    setup() {
+      return { args }
+    },
+    template: template
+  }),
+  args: { kind: 'success' }
+}
+
+// the 'gray' kind has no standard icon, so it is always paired with a custom one
+export const Gray: Story = {
+  render: (args) => ({
+    components: { NeRoundedIcon },
+    setup() {
+      return { args }
+    },
+    template: template
+  }),
+  args: { kind: 'gray', customIcon: faServer }
 }
 
 export const Custom: Story = {

--- a/stories/NeTooltip.stories.ts
+++ b/stories/NeTooltip.stories.ts
@@ -36,6 +36,9 @@ const meta = {
     triggerEvent: {
       control: 'inline-radio',
       options: triggerEventValues
+    },
+    tippyProps: {
+      control: 'object'
     }
   },
   args: { placement: 'top', triggerEvent: 'click', interactive: true } // default values
@@ -128,4 +131,18 @@ export const ContainsLink: Story = {
     template: containsLinkTemplate
   }),
   args: { placement: 'right' }
+}
+
+export const TippyProps: Story = {
+  render: (args) => ({
+    components: { NeTooltip },
+    setup() {
+      return { args }
+    },
+    template: defaultTemplate
+  }),
+  args: {
+    triggerEvent: 'mouseenter focus',
+    tippyProps: { offset: [0, 20], delay: [300, 0] }
+  }
 }

--- a/stories/PatternInlineErrorNotification.stories.ts
+++ b/stories/PatternInlineErrorNotification.stories.ts
@@ -24,23 +24,23 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const SpecificError: Story = {
-  name: 'Specific error',
+export const NetworkError: Story = {
+  name: 'Network error',
   args: {
-    title: 'Cannot retrieve phonebook contacts',
+    title: 'Cannot save phonebook contact',
     description: 'Network error. Check your connection and reload the page.'
   }
 }
 
 export const GenericError: Story = {
   name: 'Generic error',
-  args: { title: 'Cannot retrieve phonebook contacts', description: 'Something went wrong' }
+  args: { title: 'Cannot save phonebook contact', description: 'Something went wrong' }
 }
 
-export const SpecificErrorItalian: Story = {
-  name: 'Specific error (Italian)',
+export const NetworkErrorItalian: Story = {
+  name: 'Network error (Italian)',
   args: {
-    title: 'Impossibile recuperare i contatti della rubrica',
+    title: 'Impossibile salvare il contatto della rubrica',
     description: 'Errore di rete. Controlla la connessione e ricarica la pagina.'
   }
 }
@@ -48,7 +48,7 @@ export const SpecificErrorItalian: Story = {
 export const GenericErrorItalian: Story = {
   name: 'Generic error (Italian)',
   args: {
-    title: 'Impossibile recuperare i contatti della rubrica',
+    title: 'Impossibile salvare il contatto della rubrica',
     description: 'Qualcosa è andato storto'
   }
 }

--- a/stories/PatternSuccessToastNotification.stories.ts
+++ b/stories/PatternSuccessToastNotification.stories.ts
@@ -59,6 +59,17 @@ export const ItemUpdated: Story = {
   }
 }
 
+export const ItemDeleted: Story = {
+  name: 'Item deleted',
+  args: {
+    notification: {
+      ...baseNotification,
+      title: 'User deleted',
+      description: 'User Alice Fox has been deleted'
+    }
+  }
+}
+
 export const ItemCreatedItalian: Story = {
   name: 'Item created (Italian)',
   args: {
@@ -79,6 +90,18 @@ export const ItemUpdatedItalian: Story = {
       ...baseNotification,
       title: 'Utente aggiornato',
       description: "L'utente Alice Fox è stato aggiornato"
+    }
+  }
+}
+
+export const ItemDeletedItalian: Story = {
+  name: 'Item deleted (Italian)',
+  args: {
+    srCloseLabel: 'Chiudi',
+    notification: {
+      ...baseNotification,
+      title: 'Utente eliminato',
+      description: "L'utente Alice Fox è stato eliminato"
     }
   }
 }

--- a/stories/PatternTablePage.stories.ts
+++ b/stories/PatternTablePage.stories.ts
@@ -1,0 +1,449 @@
+//  Copyright (C) 2026 Nethesis S.r.l.
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import { ref } from 'vue'
+import { fn } from 'storybook/test'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import {
+  faAddressBook,
+  faCirclePlus,
+  faEye,
+  faMagnifyingGlass,
+  faPenToSquare,
+  faTrash
+} from '@fortawesome/free-solid-svg-icons'
+
+import {
+  NeButton,
+  NeDropdown,
+  NeDropdownFilterV2,
+  NeEmptyState,
+  NeHeading,
+  NePaginator,
+  NeSortDropdown,
+  NeTable,
+  NeTableBody,
+  NeTableCell,
+  NeTableHead,
+  NeTableHeadCell,
+  NeTableRow,
+  NeTextInput
+} from '../src/main'
+import type { NeDropdownFilterV2Option, NeDropdownItem, SortEvent } from '../src/main'
+
+type Contact = {
+  name: string
+  phone: string
+  company: string
+}
+
+// Names, phone numbers and company names are the same in every language, so both the
+// English and the Italian stories share this list.
+const contacts: Contact[] = [
+  { name: 'Jane Doe', phone: '+39 0123 456789', company: 'Acme Solutions' },
+  { name: 'Alice Fox', phone: '+39 0123 456712', company: 'Acme Solutions' },
+  { name: 'Marco Rossi', phone: '+39 045 9988776', company: 'Blue Ridge Systems' },
+  { name: 'Emily Carter', phone: '+44 20 7946 0102', company: 'Blue Ridge Systems' },
+  { name: 'Luca Bianchi', phone: '+39 0436 112233', company: 'Cortina Networks' },
+  { name: 'Sofia Neumann', phone: '+49 30 5557788', company: 'Delta Office IT' }
+]
+
+// The company filter options come from the data, so the two lists can't drift apart.
+const companies = [...new Set(contacts.map((contact) => contact.company))]
+
+// Every user-visible string is a prop, so a pattern is localized by passing a
+// different label set to the same render function.
+type Labels = {
+  title: string
+  pageDescription: string
+  createItem: string
+  filterItems: string
+  name: string
+  phoneNumber: string
+  company: string
+  actions: string
+  details: string
+  edit: string
+  deleteItem: string
+  resetFilters: string
+  openMenu: string
+  // empty states
+  noItemsConfigured: string
+  noItemsFound: string
+  tryChangingFilters: string
+  // sort dropdown
+  sort: string
+  sortBy: string
+  sortDirection: string
+  ascending: string
+  descending: string
+  // filter dropdown
+  clearFilter: string
+  openFilter: string
+  noOptions: string
+  moreOptionsHidden: string
+  clearSearch: string
+  optionsFilterPlaceholder: string
+  // paginator
+  previousPage: string
+  nextPage: string
+  pagination: string
+  rangeOfTotal: string
+  pageSize: string
+}
+
+const enLabels: Labels = {
+  title: 'Phonebook contacts',
+  pageDescription: 'List of phonebook contacts, including phone number and company.',
+  createItem: 'Create contact',
+  filterItems: 'Filter contacts',
+  name: 'Name',
+  phoneNumber: 'Phone number',
+  company: 'Company',
+  actions: 'Actions',
+  details: 'Details',
+  edit: 'Edit',
+  deleteItem: 'Delete',
+  resetFilters: 'Reset filters',
+  openMenu: 'Open menu',
+  noItemsConfigured: 'No contacts configured',
+  noItemsFound: 'No contacts found',
+  tryChangingFilters: 'Try changing your search filters',
+  sort: 'Sort',
+  sortBy: 'Sort by',
+  sortDirection: 'Sort direction',
+  ascending: 'Ascending',
+  descending: 'Descending',
+  clearFilter: 'Clear selection',
+  openFilter: 'Open filter',
+  noOptions: 'No options',
+  moreOptionsHidden: 'Continue typing to show more options',
+  clearSearch: 'Clear',
+  optionsFilterPlaceholder: 'Filter options',
+  previousPage: 'Go to previous page',
+  nextPage: 'Go to next page',
+  pagination: 'Pagination',
+  rangeOfTotal: 'of',
+  pageSize: 'Show'
+}
+
+const itLabels: Labels = {
+  title: 'Contatti della rubrica',
+  pageDescription: 'Elenco dei contatti della rubrica, con numero di telefono e azienda.',
+  createItem: 'Crea contatto',
+  filterItems: 'Filtra contatti',
+  name: 'Nome',
+  phoneNumber: 'Numero di telefono',
+  company: 'Azienda',
+  actions: 'Azioni',
+  details: 'Dettagli',
+  edit: 'Modifica',
+  deleteItem: 'Elimina',
+  resetFilters: 'Reimposta filtri',
+  openMenu: 'Apri menu',
+  noItemsConfigured: 'Nessun contatto configurato',
+  noItemsFound: 'Nessun contatto trovato',
+  tryChangingFilters: 'Prova a modificare i filtri di ricerca',
+  sort: 'Ordina',
+  sortBy: 'Ordina per',
+  sortDirection: 'Direzione',
+  ascending: 'Crescente',
+  descending: 'Decrescente',
+  clearFilter: 'Azzera selezione',
+  openFilter: 'Apri filtro',
+  noOptions: 'Nessuna opzione',
+  moreOptionsHidden: 'Continua a digitare per mostrare altre opzioni',
+  clearSearch: 'Cancella',
+  optionsFilterPlaceholder: 'Filtra opzioni',
+  previousPage: 'Vai alla pagina precedente',
+  nextPage: 'Vai alla pagina successiva',
+  pagination: 'Paginazione',
+  rangeOfTotal: 'di',
+  pageSize: 'Mostra'
+}
+
+const meta = {
+  title: 'Patterns/Table page',
+  component: NeTable,
+  argTypes: {
+    cardBreakpoint: { control: 'inline-radio', options: ['sm', 'md', 'lg', 'xl', '2xl'] }
+  },
+  args: {
+    cardBreakpoint: 'lg',
+    loading: false,
+    skeletonRows: 7,
+    skeletonColumns: 4
+  }
+} satisfies Meta<typeof NeTable>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// What sits below the toolbar is the only difference between the page states, so a
+// single template branches on the variant, like the real page does.
+type Variant = 'table' | 'noItemsConfigured' | 'noItemsFound'
+
+// The whole page is a composition of components and slot content, which can't be
+// args, so the stories use a render function. Only the table props stay editable
+// as controls; every label comes from the label set passed to renderTablePage().
+const tablePageTemplate = `<div>
+  <!-- page header: title and description on the left, primary action on the right -->
+  <NeHeading tag="h3">{{ labels.title }}</NeHeading>
+  <div class="mb-8 flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
+    <p class="mt-2 max-w-2xl text-gray-500 dark:text-gray-400">
+      {{ labels.pageDescription }}
+    </p>
+    <NeButton kind="primary" size="lg" class="shrink-0" @click="noop">
+      <template #prefix>
+        <FontAwesomeIcon :icon="faCirclePlus" aria-hidden="true" />
+      </template>
+      {{ labels.createItem }}
+    </NeButton>
+  </div>
+  <!-- table toolbar -->
+  <div class="mb-6 flex flex-wrap items-center gap-4">
+    <!-- text filter -->
+    <NeTextInput
+      v-model="textFilter"
+      is-search
+      :placeholder="labels.filterItems"
+      :clear-search-label="labels.clearSearch"
+      class="max-w-48 sm:max-w-sm"
+    />
+    <!-- company filter -->
+    <NeDropdownFilterV2
+      v-model="companyFilter"
+      kind="checkbox"
+      :label="labels.company"
+      :options="companyFilterOptions"
+      :clear-filter-label="labels.clearFilter"
+      :open-menu-aria-label="labels.openFilter"
+      :no-options-label="labels.noOptions"
+      :more-options-hidden-label="labels.moreOptionsHidden"
+      :clear-search-label="labels.clearSearch"
+      :options-filter-placeholder="labels.optionsFilterPlaceholder"
+    />
+    <!-- sort dropdown -->
+    <NeSortDropdown
+      v-model:sort-key="sortKey"
+      v-model:sort-descending="sortDescending"
+      :label="labels.sort"
+      :options="sortOptions"
+      :open-menu-aria-label="labels.openMenu"
+      :sort-by-label="labels.sortBy"
+      :sort-direction-label="labels.sortDirection"
+      :ascending-label="labels.ascending"
+      :descending-label="labels.descending"
+    />
+    <NeButton kind="tertiary" @click="resetFilters">{{ labels.resetFilters }}</NeButton>
+  </div>
+  <!-- no contact configured yet -->
+  <NeEmptyState
+    v-if="variant === 'noItemsConfigured'"
+    :icon="faAddressBook"
+    :title="labels.noItemsConfigured"
+    class="bg-white dark:bg-gray-950"
+  >
+    <NeButton kind="primary" size="lg" @click="noop">
+      <template #prefix>
+        <FontAwesomeIcon :icon="faCirclePlus" aria-hidden="true" />
+      </template>
+      {{ labels.createItem }}
+    </NeButton>
+  </NeEmptyState>
+  <!-- no contact matching the filters -->
+  <NeEmptyState
+    v-else-if="variant === 'noItemsFound'"
+    :icon="faMagnifyingGlass"
+    :title="labels.noItemsFound"
+    :description="labels.tryChangingFilters"
+    class="bg-white dark:bg-gray-950"
+  >
+    <NeButton kind="tertiary" size="lg" @click="resetFilters">{{ labels.resetFilters }}</NeButton>
+  </NeEmptyState>
+  <NeTable v-else v-bind="args" :sort-key="sortKey" :sort-descending="sortDescending">
+    <NeTableHead>
+      <NeTableHeadCell sortable column-key="name" @sort="onSort">
+        {{ labels.name }}
+      </NeTableHeadCell>
+      <NeTableHeadCell>{{ labels.phoneNumber }}</NeTableHeadCell>
+      <NeTableHeadCell sortable column-key="company" @sort="onSort">
+        {{ labels.company }}
+      </NeTableHeadCell>
+      <NeTableHeadCell>
+        <!-- no header for actions -->
+      </NeTableHeadCell>
+    </NeTableHead>
+    <NeTableBody>
+      <NeTableRow v-for="(contact, index) in contacts" :key="index">
+        <NeTableCell :data-label="labels.name">
+          <!-- justify-self-start and text-left keep the button aligned with the other
+               cell values in card layout, where the cell is a two-column grid -->
+          <button
+            type="button"
+            class="cursor-pointer justify-self-start text-left font-medium hover:underline"
+            @click="noop"
+          >
+            {{ contact.name }}
+          </button>
+        </NeTableCell>
+        <NeTableCell :data-label="labels.phoneNumber">{{ contact.phone }}</NeTableCell>
+        <NeTableCell :data-label="labels.company">{{ contact.company }}</NeTableCell>
+        <NeTableCell :data-label="labels.actions">
+          <div class="-ml-2.5 flex gap-2 lg:ml-0 lg:justify-end">
+            <NeButton kind="tertiary" @click="noop">
+              <template #prefix>
+                <FontAwesomeIcon :icon="faEye" class="h-4 w-4" aria-hidden="true" />
+              </template>
+              {{ labels.details }}
+            </NeButton>
+            <!-- kebab menu -->
+            <NeDropdown
+              :items="kebabMenuItems"
+              align-to-right
+              :open-menu-aria-label="labels.openMenu"
+            />
+          </div>
+        </NeTableCell>
+      </NeTableRow>
+    </NeTableBody>
+    <template #paginator>
+      <NePaginator
+        :current-page="1"
+        :total-rows="contacts.length"
+        :page-size="10"
+        :page-sizes="[5, 10, 25, 50, 100]"
+        :previous-label="labels.previousPage"
+        :next-label="labels.nextPage"
+        :nav-pagination-label="labels.pagination"
+        :range-of-total-label="labels.rangeOfTotal"
+        :page-size-label="labels.pageSize"
+      />
+    </template>
+  </NeTable>
+</div>`
+
+function renderTablePage(labels: Labels, variant: Variant = 'table'): Story['render'] {
+  return (args) => ({
+    components: {
+      NeButton,
+      NeDropdown,
+      NeDropdownFilterV2,
+      NeEmptyState,
+      NeHeading,
+      NePaginator,
+      NeSortDropdown,
+      NeTable,
+      NeTableBody,
+      NeTableCell,
+      NeTableHead,
+      NeTableHeadCell,
+      NeTableRow,
+      NeTextInput,
+      FontAwesomeIcon
+    },
+    setup() {
+      const companyFilterOptions: NeDropdownFilterV2Option[] = companies.map((company) => ({
+        id: company,
+        label: company
+      }))
+
+      const textFilter = ref('')
+      const companyFilter = ref<NeDropdownFilterV2Option[]>([])
+      const sortKey = ref('name')
+      const sortDescending = ref(false)
+
+      // The pattern has no logic: filters and kebab actions don't touch the rows,
+      // and sorting only moves the indicator.
+      const noop = fn()
+
+      function resetFilters() {
+        textFilter.value = ''
+        companyFilter.value = []
+      }
+
+      function onSort(payload: SortEvent) {
+        sortKey.value = payload.key
+        sortDescending.value = payload.descending
+      }
+
+      const kebabMenuItems: NeDropdownItem[] = [
+        { id: 'edit', label: labels.edit, icon: faPenToSquare, action: noop },
+        { id: 'delete', label: labels.deleteItem, icon: faTrash, danger: true, action: noop }
+      ]
+
+      return {
+        args,
+        labels,
+        variant,
+        contacts,
+        companyFilterOptions,
+        textFilter,
+        companyFilter,
+        sortKey,
+        sortDescending,
+        sortOptions: [
+          { id: 'name', label: labels.name },
+          { id: 'company', label: labels.company }
+        ],
+        kebabMenuItems,
+        resetFilters,
+        onSort,
+        noop,
+        faAddressBook,
+        faCirclePlus,
+        faEye,
+        faMagnifyingGlass
+      }
+    },
+    template: tablePageTemplate
+  })
+}
+
+export const Standard: Story = {
+  args: { ariaLabel: 'Phonebook contacts' },
+  render: renderTablePage(enLabels)
+}
+
+export const Loading: Story = {
+  args: { ariaLabel: 'Phonebook contacts', loading: true },
+  render: renderTablePage(enLabels)
+}
+
+export const NoItemsConfigured: Story = {
+  name: 'No items configured',
+  args: { ariaLabel: 'Phonebook contacts' },
+  render: renderTablePage(enLabels, 'noItemsConfigured')
+}
+
+export const NoItemsFound: Story = {
+  name: 'No items found',
+  args: { ariaLabel: 'Phonebook contacts' },
+  render: renderTablePage(enLabels, 'noItemsFound')
+}
+
+export const StandardItalian: Story = {
+  name: 'Standard (Italian)',
+  args: { ariaLabel: 'Contatti della rubrica' },
+  render: renderTablePage(itLabels)
+}
+
+export const LoadingItalian: Story = {
+  name: 'Loading (Italian)',
+  args: { ariaLabel: 'Contatti della rubrica', loading: true },
+  render: renderTablePage(itLabels)
+}
+
+export const NoItemsConfiguredItalian: Story = {
+  name: 'No items configured (Italian)',
+  args: { ariaLabel: 'Contatti della rubrica' },
+  render: renderTablePage(itLabels, 'noItemsConfigured')
+}
+
+export const NoItemsFoundItalian: Story = {
+  name: 'No items found (Italian)',
+  args: { ariaLabel: 'Contatti della rubrica' },
+  render: renderTablePage(itLabels, 'noItemsFound')
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
         '@fortawesome/vue-fontawesome',
         '@fortawesome/free-solid-svg-icons',
         '@headlessui/vue',
-        'uuid',
         'lodash-es',
         '@vueuse/core'
       ],
@@ -30,7 +29,6 @@ export default defineConfig({
           '@fortawesome/vue-fontawesome': 'FontAwesomeIcon',
           '@fortawesome/free-solid-svg-icons': 'fa',
           '@headlessui/vue': 'HeadlessUI',
-          uuid: 'v',
           'lodash-es': 'uniqBy',
           '@vueuse/core': 'onClickOutside'
         }


### PR DESCRIPTION
- **NeDropdownFilterV2** — selected options are pinned at the top, snapshotted on menu open so
  the list doesn't reshuffle while selecting; pinned rows count towards `maxOptionsShown`,
  dividers are proper separators, and the "more options hidden" hint is now accurate. The
  internal search now matches option descriptions too, not just labels and group names.
  Selection badges in the trigger button now use the `indigo` kind.
- **dateTime** — new `formatRelativeTime` (Intl.RelativeTimeFormat, e.g. "2 hours ago",
  "Yesterday"), `formatDateTime` / `formatDateTimeNoSeconds` with optional time zone, and
  `getBrowserLocale`. `humanDistanceToNowLoc` is deprecated. Loose `any` signatures replaced
  with real types; invalid dates render `-` and log a warning.
- **NeCombobox** — new `selectedOption` prop (single selection only): when the option matching
  `modelValue` isn't in `options` — the case `externalFilter` creates, where the parent only
  supplies one page of a server-side result set.
- **NeTooltip** — new `tippyProps` prop to forward any Tippy option, plus an exported
  `TippyComponentProps` type.
- **NeToastNotificationV2** — timestamp uses the new relative-time formatter and renders its
  tooltip on `document.body`, so the timestamp tooltip is no longer clipped by the toast container.
- **NeRoundedIcon** — new `gray` kind; `customIcon` now takes precedence over the kind default.
- **NeModal** — with three buttons, Cancel moves to the left side of the footer.
- **Chore** — drop the `uuid` dependency in favour of Vue's `useId`; new `capitalizeFirst`
  util; new `Patterns/TablePage` Storybook story and stories for the changes above.

### Notes

- Backwards compatible: `humanDistanceToNowLoc` still works but is marked `@deprecated`.
- `uuid` / `@types/uuid` removed from `package.json` and from the Vite externals.
