### PR TITLE
fix(build): restore missing type declarations in published package

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,6 +16,9 @@ COPY vite.config.ts .
 
 FROM app as build
 RUN npm run build
+# Declaration emit can fail silently (see the "noEmit" note in tsconfig.app.json).
+# Never ship a package without types.
+RUN test -f dist/main.d.ts
 
 FROM app as build-storybook
 COPY .storybook .storybook

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,6 +4,10 @@
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,
+    // @vue/tsconfig >= 0.9 sets "noEmit": true in its base config, which silently
+    // suppresses declaration emit even with --emitDeclarationOnly on the CLI.
+    // We publish declarations, so keep emit enabled here.
+    "noEmit": false,
     "baseUrl": ".",
     "outDir": "dist"
   }


### PR DESCRIPTION
`v3.12.0` was published without any type declarations: the tarball contains zero `.d.ts` files, while `package.json` still points `"types"` at `./dist/main.d.ts`. Consumers get `TS7016` on every import of the package, plus `TS2307` on subpath type imports such as `@nethesis/vue-components/components/NeTooltip.vue.js`.

**Root cause:** #100 bumped `@vue/tsconfig` from `^0.4.0` to `^0.9.0` two commits before the release. `@vue/tsconfig` 0.9.0 added `"noEmit": true` to its base config, which `tsconfig.app.json` inherits through `tsconfig.dom.json`. Under TypeScript 5.9 `--emitDeclarationOnly` on the CLI does not clear `noEmit`, and the pairing is no longer a diagnostic — `handleNoEmitOptions` skips emit and returns success. So `build-types` type-checked, wrote nothing and exited 0.

### Changes

- `tsconfig.app.json` — set `"noEmit": false` explicitly, so declaration emit no longer depends on what `@vue/tsconfig` ships in its base config.
- `Containerfile` — assert `dist/main.d.ts` exists after the build. The failure above was entirely silent; this turns it into a build error instead of a bad publish. It covers both the release workflow and the CI `dist` job, since both go through `build.sh dist`.

